### PR TITLE
Added OFDMA Calculator

### DIFF
--- a/OFDMA Calculator v0.3a.html
+++ b/OFDMA Calculator v0.3a.html
@@ -1,0 +1,5344 @@
+<meta charset="utf8" />
+<html>
+
+<head>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <link href="dist/fontawesome/css/all.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+  <style>
+    tr {
+      width: 100%;
+    }
+
+    .selected-row {
+      background-color: aliceblue
+    }
+
+    .just-padding {
+      padding: 5px;
+    }
+
+    .list-group.list-group-root {
+      padding: 0;
+      overflow: hidden;
+    }
+
+    .list-group.list-group-root .list-group {
+      margin-bottom: 0;
+    }
+
+    .list-group.list-group-root .list-group-item {
+      border-radius: 0;
+      border-width: 1px 0 0 0;
+    }
+
+    .list-group.list-group-root>.list-group-item:first-child {
+      border-top-width: 0;
+    }
+
+    .list-group.list-group-root>.list-group>.list-group-item {
+      padding-left: 30px;
+    }
+
+    .list-group.list-group-root>.list-group>.list-group>.list-group-item {
+      padding-left: 45px;
+    }
+
+    .list-group-item .glyphicon {
+      margin-right: 5px;
+    }
+  </style>
+  <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
+
+  <script>
+    // OFDMA LIB
+    /*
+    calculate minislotCapacity
+    */
+    let modulationLookup = {
+      "zeroValued": 0,
+      "bpsk": 8,
+      "qpsk": 11,
+      "8qam": 14,
+      "16qam": 17,
+      "32qam": 20,
+      "64qam": 23,
+      "128qam": 26,
+      "256qam": 29,
+      "512qam": 32.5,
+      "1024qam": 35.5,
+      "2048qam": 39,
+      "4096qam": 42.5
+    };
+    let bandwidthModulationLookup = {
+      "qpsk": 2,
+      "8qam": 3,
+      "16qam": 4,
+      "32qam": 5,
+      "64qam": 6,
+      "128qam": 7,
+      "256qam": 8,
+      "512qam": 9,
+      "1024qam": 10,
+      "2048qam": 11,
+      "4096qam": 12
+    };
+    let cpLookup = {
+      96: 0.000000937,
+      128: 0.00000125,
+      160: 0.000001562,
+      192: 0.000001875,
+      224: 0.0000021875,
+      256: 0.0000025,
+      320: 0.000003125,
+      384: 0.00000375,
+      512: 0.000005,
+      640: 0.00000625
+    };
+    let rpLookup = {
+      0: 0,
+      32: 0.000000312,
+      64: 0.000000625,
+      96: 0.000000937,
+      128: 0.00000125,
+      160: 0.000001562,
+      192: 0.000001875,
+      224: 0.0000021875
+    };
+    let symbolDurationLookup = {
+      50000: 0.00002,
+      25000: 0.00004
+    };
+
+    function minislotCapacity(numberOfSymbolsPerFrame, ModulationOrder, pilotPattern) {
+      //# Pattern Number, minislotsubcarriersQ, Body0/Edge1 , Num Pilots, Num CP
+      let bodyMinislotPatterns = [
+        [],
+        // 50 KHz spacing Pilot patterns 1-4 on Casa
+        // Body
+        [1, 8, 0, 2, 2],
+        [2, 8, 0, 4, 2],
+        [3, 8, 0, 8, 2],
+        [4, 8, 0, 16, 2],
+        // 25 Khz spacing Pilot Patterns 5-11 on Casa
+        [5, 16, 0, 2, 2],
+        [6, 16, 0, 4, 2],
+        [7, 16, 0, 8, 2],
+        [8, 16, 0, 16, 2],
+        [9, 16, 0, 1, 1],
+        [10, 16, 0, 2, 1],
+        [11, 16, 0, 4, 1],
+
+      ];
+
+      let edgeMinislotPatterns = [
+        [],
+        // 50 KHz spacing Pilot patterns 1-4 on Casa
+        // Edge
+        [1, 8, 1, 4, 4],
+        [2, 8, 1, 6, 4],
+        [3, 8, 1, 10, 4],
+        [4, 8, 1, 16, 4],
+        // 25 KHz spacing Pilot Patterns 5-11 on Casa
+        [5, 16, 1, 4, 4],
+        [6, 16, 1, 6, 4],
+        [7, 16, 1, 10, 4],
+        [8, 16, 1, 18, 4],
+        [9, 16, 1, 2, 2],
+        [10, 16, 1, 3, 2],
+        [11, 16, 1, 5, 2],
+      ];
+      /*let minislotpatterns = [
+        [],
+        // 50 KHz spacing Pilot patterns 1-4 on Casa
+        // Body
+        [1, 8, 0, 2, 2],
+        [2, 8, 0, 4, 2],
+        [3, 8, 0, 8, 2],
+        [4, 8, 0, 16, 2],
+        // Edge
+        [1, 8, 1, 4, 4],
+        [2, 8, 1, 6, 4],
+        [3, 8, 1, 10, 4],
+        [4, 8, 1, 16, 4],
+        /*
+        Casa does not support boosted pilots on 50 KHz
+        [5, 8, 0, 1, 1],
+        [6, 8, 0, 2, 1],
+        [7, 8, 0, 4, 1],
+        
+        [5, 8, 1, 2, 2],
+        [6, 8, 1, 3, 2],
+        [7, 8, 1, 5, 2],
+        
+        [8, 16, 0, 2, 2],
+        [9, 16, 0, 4, 2],
+        [10, 16, 0, 8, 2],
+        [11, 16, 0, 16, 2],
+        [12, 16, 0, 1, 1],
+        [13, 16, 0, 2, 1],
+        [14, 16, 0, 4, 1],
+        [8, 16, 1, 4, 4],
+        [9, 16, 1, 6, 4],
+        [10, 16, 1, 10, 4],
+        [11, 16, 1, 18, 4],
+        [12, 16, 1, 2, 2],
+        [13, 16, 1, 3, 2],
+        [14, 16, 1, 5, 2],
+      ];
+      */
+      if (pilotPattern < 5) {
+
+      }
+      let subcarriersPerMinislot = bodyMinislotPatterns[pilotPattern][1];
+      let cpModulationOrder = Math.max(ModulationOrder - 4, 1);
+      let subcarriers = numberOfSymbolsPerFrame * subcarriersPerMinislot - (bodyMinislotPatterns[pilotPattern][3] + edgeMinislotPatterns[pilotPattern][3]) - (bodyMinislotPatterns[pilotPattern][4] + edgeMinislotPatterns[pilotPattern][4]);
+      let minislotCapacity = (ModulationOrder * subcarriers) + (cpModulationOrder * (bodyMinislotPatterns[pilotPattern][4] + edgeMinislotPatterns[pilotPattern][4]));
+      //console.log(K, Modulationorder, pattern_index, Q, cp_modulation_order, subcarriers, mscapacity);
+      return minislotCapacity;
+    }
+
+    function subcarrierZeroFrequency(lowerFreq, subcarrierSpacing) {
+      if (subcarrierSpacing !== 25000 && subcarrierSpacing !== 50000) {
+        throw Error(`unknown subcarrier spacing ${subcarrierSpacing}`);
+      }
+      if (lowerFreq < 5000000) {
+        throw new Error("lower-freq must be at least 5 MHz");
+      }
+      let manualOrAuto = document.getElementById("boundaryType").value;
+      if (manualOrAuto == "manual") {
+        while ((lowerFreq + (subcarrierSpacing / 2)) % subcarrierSpacing !== 0) {
+          lowerFreq += 1;
+        }
+        return lowerFreq - 3700000 + (subcarrierSpacing / 2);
+      } else {
+        while ((lowerFreq) % subcarrierSpacing !== 0) {
+          lowerFreq += 1;
+        }
+        return lowerFreq - 3700000;
+      }
+      
+
+    }
+
+    function subcarriers(subcarrierSpacing, subcarrierZeroFrequency, upperFreq) {
+      // lower Freq 50 Khz = SC0 + 74 * scSpacing - (scSpacing /2)
+      // lower freq 25 khz = SC0 + 148 * scSpacing - (scSpacing /2)
+      if (upperFreq - ((subcarrierZeroFrequency - (subcarrierSpacing / 2)) + 3700000) > 94800000) {
+        throw new Error(`upper-freq can't be more than 94.8 MHz more than lower-freq`);
+      }
+      if (subcarrierSpacing === 50000 && upperFreq - ((subcarrierZeroFrequency - (subcarrierSpacing / 2)) + 3700000) < 10000000) {
+        throw new Error(`upper-freq can't be less than 10 MHz more than lower-freq when subcarrier spacing is 50 Khz`);
+      } else if (subcarrierSpacing === 25000 && upperFreq - ((subcarrierZeroFrequency - (subcarrierSpacing / 2)) + 3700000) < 6400000) {
+        throw new Error(`upper-freq can't be less than 6.4 MHz more than lower-freq when subcarrier spacing is 25 Khz`);
+      }
+      let numSubCarriers;
+      if (subcarrierSpacing === 50000) {
+        numSubCarriers = 2048;
+      }
+      else if (subcarrierSpacing === 25000) {
+        numSubCarriers = 4096;
+      }
+      else {
+        throw Error(`unknown subcarrier spacing ${subcarrierSpacing}`);
+      }
+      let subcarriers = [];
+      let manualOrAuto = document.getElementById("boundaryType").value;
+      for (let x = 0; x < numSubCarriers; x++) {
+        let startFrequency = subcarrierZeroFrequency + (x * subcarrierSpacing) - (subcarrierSpacing / 2);
+        let centerFrequency = subcarrierZeroFrequency + (x * subcarrierSpacing);
+        
+        let endFrequency = subcarrierZeroFrequency + (x * subcarrierSpacing) + (subcarrierSpacing / 2);
+        if (manualOrAuto == "manual" && centerFrequency >= (subcarrierZeroFrequency + 3700000) && endFrequency <= upperFreq) {
+          subcarriers.push({ index: x, startFrequency, centerFrequency, endFrequency, type: 'data' });
+        } else if (manualOrAuto == "auto" && centerFrequency >= (subcarrierZeroFrequency + 3700000) && endFrequency <= (upperFreq + (subcarrierSpacing / 2))) {
+          subcarriers.push({ index: x, startFrequency, centerFrequency, endFrequency, type: 'data' });
+        }
+        else {
+          subcarriers.push({ index: x, startFrequency, centerFrequency, endFrequency, type: 'excluded' });
+        }
+      }
+      return subcarriers;
+    }
+
+    function setExclusionBands(subcarriers, excludedSubcarriers) {
+      subcarriers.forEach((row, index, array) => {
+        if (excludedSubcarriers.includes(index)) {
+          array[index].type = 'excluded';
+        }
+      });
+      return subcarriers;
+    }
+
+    function generateMinislots(subcarriers, subcarrierSpacing) {
+      let scsInMinislot, endExcluded;
+
+      if (subcarrierSpacing === 25000) {
+        scsInMinislot = 16;
+        endExcluded = 3948;
+      }
+      else {
+        scsInMinislot = 8;
+        endExcluded = 1974;
+      }
+      let minislotCounter = 0;
+      let unusedCounter = 0;
+      let firstDatSc = subcarriers.findIndex((sc) => {
+        return sc.type === "data";
+      });
+      for (let x = firstDatSc; x < endExcluded; x++) {
+        let potentialMinislot = subcarriers.slice(x, x + (scsInMinislot));
+        let includesExcludedSubcarriers = potentialMinislot.findIndex((sc) => {
+
+          return sc.type == "excluded";
+
+        });
+        if (includesExcludedSubcarriers !== -1) {
+          for (let z = x; z < (x + includesExcludedSubcarriers); z++) {
+            subcarriers[z].type = "unused";
+            unusedCounter++;
+          }
+          x += (includesExcludedSubcarriers);
+        }
+        else {
+          // found Minislot
+          for (let y = x; y < (x + scsInMinislot); y++) {
+            subcarriers[y].minislot = minislotCounter;
+          }
+          minislotCounter++;
+          x += (scsInMinislot - 1);
+        }
+      }
+      subcarriers.minislots = minislotCounter;
+      subcarriers.unusedCarriers = unusedCounter;
+      return subcarriers;
+    }
+    function calculateGuardband(ofmdaCenterFreq, ofdmaLowerFreq, ofdmaUpperFreq, subcarrierSpacing, ofdmaRxPower, ofdmaRxMerTarget, adjacentUpstream, cyclicPrefix) {
+
+      let x = ofdmaRxPower;
+      let y = Number(adjacentUpstream.rxPower);
+      let adjSc, adjRd;
+      switch (adjacentUpstream.channelWidth / 1000000) {
+        case 6.4:
+          adjSc = 6;
+          adjRd = 26;
+          break;
+        case 3.2:
+          adjSc = 3;
+          adjRd = 24;
+          break;
+        case 1.6:
+          adjSc = 0;
+          adjRd = 21;
+      }
+      let snr20 = ofdmaRxMerTarget - x + y - adjSc - adjRd + 6;
+
+      let tempGuardbandA;
+      if (snr20 <= 4) {
+        tempGuardbandA = .25;
+      } else if (snr20 <= 5) {
+        tempGuardbandA = .5;
+      } else if (snr20 <= 7) {
+        tempGuardbandA = .75;
+      } else if (snr20 <= 9) {
+        tempGuardbandA = 1;
+      } else if (snr20 <= 11) {
+        tempGuardbandA = 1.25;
+      } else if (snr20 <= 13) {
+        tempGuardbandA = 1.5;
+      } else {
+        tempGuardbandA = 2;
+      }
+      let tempGuardbandB;
+      if (snr20 <= 1.25) {
+        tempGuardbandB = .25;
+      } else if (snr20 <= 2) {
+        tempGuardbandB = .5;
+      } else if (snr20 <= 2.1) {
+        tempGuardbandB = .75;
+      } else if (snr20 <= 2.75) {
+        tempGuardbandB = 1;
+      } else if (snr20 <= 3.5) {
+        tempGuardbandB = 1.25;
+      } else if (snr20 <= 4.3) {
+        tempGuardbandB = 1.5;
+      } else if (snr20 <= 5.25) {
+        tempGuardbandB = 2;
+      } else if (snr20 <= 6.5) {
+        tempGuardbandB = 2.0;
+      } else if (snr20 <= 7.5) {
+        tempGuardbandB = 2.25;
+      } else if (snr20 <= 9) {
+        tempGuardbandB = 2.5;
+      } else if (snr20 <= 10.5) {
+        tempGuardbandB = 2.75;
+      } else if (snr20 <= 12.5) {
+        tempGuardbandB = 3;
+      } else if (snr20 <= 14.5) {
+        tempGuardbandB = 3.25;
+      } else if (snr20 <= 16.7) {
+        tempGuardbandB = 3.5;
+      } else {
+        tempGuardbandB = 3.76;
+      }
+      tempGuardbandA = tempGuardbandA * 1000000;
+      tempGuardbandB = tempGuardbandB * 1000000;
+      // Determine narrow filter size
+      let tempNarrowFilterA, tempNarrowFilterB;
+      let endOfGuardbandA = adjacentUpstream.centerFrequency + ((adjacentUpstream.channelWidth) / 2) + tempGuardbandA;
+      let endOfGuardbandB = adjacentUpstream.centerFrequency + ((adjacentUpstream.channelWidth) / 2) + tempGuardbandB;
+
+      for (let x = 5000000; x < 100000000; x += 5000000) {
+        if (endOfGuardbandA + x > ofdmaUpperFreq) {
+          tempNarrowFilterA = x;
+          break;
+        }
+      }
+      for (let x = 5000000; x < 100000000; x += 5000000) {
+        if (endOfGuardbandB + x > ofdmaUpperFreq) {
+          tempNarrowFilterB = x;
+          break;
+        }
+      }
+      let tempNarrowFilterCenterA, tempNarrowFilterCenterB;
+      tempNarrowFilterCenterA = endOfGuardbandA + (tempNarrowFilterA / 2);
+      tempNarrowFilterCenterB = endOfGuardbandB + (tempNarrowFilterB / 2);
+      let centerDiffA = tempNarrowFilterCenterA - ofmdaCenterFreq;
+      let centerDiffB = tempNarrowFilterCenterB - ofmdaCenterFreq;
+      let adjA = 0, adjB = 0;
+      if (centerDiffA % subcarrierSpacing !== 0) {
+        adjA = subcarrierSpacing - centerDiffA % subcarrierSpacing;
+        centerDiffA += adjA;
+        tempGuardbandA += adjA;
+      }
+      if (centerDiffB % subcarrierSpacing !== 0) {
+        adjB = subcarrierSpacing - centerDiffB % subcarrierSpacing;
+        centerDiffB += adjB;
+        tempGuardbandB += adjB;
+      }
+      //console.log(ofmdaCenterFreq, ofdmaLowerFreq, ofdmaUpperFreq, subcarrierSpacing, ofdmaRxPower, ofdmaRxMerTarget, adjacentUpstream, cyclicPrefix, ofdmaRxMerTarget, x , y, adjSc , adjRd, snr20, tempGuardbandA, tempGuardbandB, adjA, adjB );
+
+      let tafdmCp = "";
+      switch (parseInt(cyclicPrefix, 10)) {
+        case 640:
+          tafdmCp = "TaFDM Required please use Cyclic Prefix of 512";
+          if ((centerDiffA / subcarrierSpacing % 4 !== 0)) {
+            adjA += (centerDiffA / subcarrierSpacing % 4) * subcarrierSpacing;
+          }
+          if ((centerDiffB / subcarrierSpacing % 4 !== 0)) {
+            adjB += (centerDiffB / subcarrierSpacing % 4) * subcarrierSpacing;
+          }
+          tempGuardbandA += adjA;
+          tempGuardbandB += adjB;
+          break;
+        case 512:
+          if ((centerDiffA / subcarrierSpacing % 4 !== 0)) {
+            adjA += (centerDiffA / subcarrierSpacing % 4) * subcarrierSpacing;
+          }
+          if ((centerDiffB / subcarrierSpacing % 4 !== 0)) {
+            adjB += (centerDiffB / subcarrierSpacing % 4) * subcarrierSpacing;
+          }
+          tempGuardbandA += adjA;
+          tempGuardbandB += adjB;
+          break;
+        case 384:
+          tafdmCp = "TaFDM Required please use Cyclic Prefix of 512";
+          if ((centerDiffA / subcarrierSpacing % 4 !== 0)) {
+            adjA += (centerDiffA / subcarrierSpacing % 4) * subcarrierSpacing;
+          }
+          if ((centerDiffB / subcarrierSpacing % 4 !== 0)) {
+            adjB += (centerDiffB / subcarrierSpacing % 4) * subcarrierSpacing;
+          }
+          tempGuardbandA += adjA;
+          tempGuardbandB += adjB;
+        case 320:
+          tafdmCp = "TaFDM Required please use Cyclic Prefix of 256";
+          if ((centerDiffA / subcarrierSpacing % 8 !== 0)) {
+            adjA += (centerDiffA / subcarrierSpacing % 8) * subcarrierSpacing;
+          }
+          if ((centerDiffB / subcarrierSpacing % 8 !== 0)) {
+            adjB += (centerDiffB / subcarrierSpacing % 8) * subcarrierSpacing;
+          }
+          tempGuardbandA += adjA;
+          tempGuardbandB += adjB;
+        case 288:
+          tafdmCp = "TaFDM Required please use Cyclic Prefix of 256";
+          if ((centerDiffA / subcarrierSpacing % 8 !== 0)) {
+            adjA += (centerDiffA / subcarrierSpacing % 8) * subcarrierSpacing;
+          }
+          if ((centerDiffB / subcarrierSpacing % 8 !== 0)) {
+            adjB += (centerDiffB / subcarrierSpacing % 8) * subcarrierSpacing;
+          }
+          tempGuardbandA += adjA;
+          tempGuardbandB += adjB;
+        case 256:
+          if ((centerDiffA / subcarrierSpacing % 8 !== 0)) {
+            adjA += (centerDiffA / subcarrierSpacing % 8) * subcarrierSpacing;
+          }
+          if ((centerDiffB / subcarrierSpacing % 8 !== 0)) {
+            adjB += (centerDiffB / subcarrierSpacing % 8) * subcarrierSpacing;
+          }
+          tempGuardbandA += adjA;
+          tempGuardbandB += adjB;
+          break;
+        case 224:
+          tafdmCp = "TaFDM Required please use Cyclic Prefix of 256";
+          if ((centerDiffA / subcarrierSpacing % 8 !== 0)) {
+            adjA += (centerDiffA / subcarrierSpacing % 8) * subcarrierSpacing;
+          }
+          if ((centerDiffB / subcarrierSpacing % 8 !== 0)) {
+            adjB += (centerDiffB / subcarrierSpacing % 8) * subcarrierSpacing;
+          }
+          tempGuardbandA += adjA;
+          tempGuardbandB += adjB;
+        case 192:
+          tafdmCp = "TaFDM Required please use Cyclic Prefix of 128";
+          if ((centerDiffA / subcarrierSpacing % 16 !== 0)) {
+            adjA += (centerDiffA / subcarrierSpacing % 16) * subcarrierSpacing;
+          }
+          if ((centerDiffB / subcarrierSpacing % 16 !== 0)) {
+            adjB += (centerDiffB / subcarrierSpacing % 16) * subcarrierSpacing;
+          }
+          tempGuardbandA += adjA;
+          tempGuardbandB += adjB;
+          break;
+        case 160:
+          tafdmCp = "TaFDM Required please use Cyclic Prefix of 128";
+          if ((centerDiffA / subcarrierSpacing % 16 !== 0)) {
+            adjA += (centerDiffA / subcarrierSpacing % 16) * subcarrierSpacing;
+          }
+          if ((centerDiffB / subcarrierSpacing % 16 !== 0)) {
+            adjB += (centerDiffB / subcarrierSpacing % 16) * subcarrierSpacing;
+          }
+          tempGuardbandA += adjA;
+          tempGuardbandB += adjB;
+          break;
+        case 128:
+          if ((centerDiffA / subcarrierSpacing % 16 !== 0)) {
+            adjA += (centerDiffA / subcarrierSpacing % 16) * subcarrierSpacing;
+          }
+          if ((centerDiffB / subcarrierSpacing % 16 !== 0)) {
+            adjB += (centerDiffB / subcarrierSpacing % 16) * subcarrierSpacing;
+          }
+          tempGuardbandA += adjA;
+          tempGuardbandB += adjB;
+          break;
+        case 96:
+          tafdmCp = "TaFDM Required please use Cyclic Prefix of 128";
+          if ((centerDiffA / subcarrierSpacing % 16 !== 0)) {
+            adjA += (centerDiffA / subcarrierSpacing % 16) * subcarrierSpacing;
+          }
+          if ((centerDiffB / subcarrierSpacing % 16 !== 0)) {
+            adjB += (centerDiffB / subcarrierSpacing % 16) * subcarrierSpacing;
+          }
+          tempGuardbandA += adjA;
+          tempGuardbandB += adjB;
+          break;
+      }
+      let warnings = [], tafdmGuardbandA, tafdmGuardbandB;
+      if (tafdmCp !== "") {
+        warnings.push(tafdmCp);
+      }
+      if ((adjacentUpstream.centerFrequency + ((adjacentUpstream.channelWidth / 2)) + tempGuardbandA) > ofdmaLowerFreq && (adjacentUpstream.centerFrequency - ((adjacentUpstream.channelWidth / 2)) - tempGuardbandA) < ofdmaUpperFreq) {
+        tafdmGuardbandA = true;
+      }
+      if ((adjacentUpstream.centerFrequency + ((adjacentUpstream.channelWidth / 2)) + tempGuardbandB) > ofdmaLowerFreq && (adjacentUpstream.centerFrequency - ((adjacentUpstream.channelWidth / 2)) - tempGuardbandB) < ofdmaUpperFreq) {
+        tafdmGuardbandB = true;
+      }
+      return {
+        Regular: tafdmGuardbandA,
+        Alternate: tafdmGuardbandB,
+        guardbandA: parseFloat(tempGuardbandA.toFixed(2)),
+        guardbandB: parseFloat(tempGuardbandB.toFixed(2)),
+        warnings
+      };
+    }
+    // End OFDMA LIB
+    /* global google $*/
+    let cp1 = 256;
+    let rp1 = 128;
+    let excludedScs = false;
+    let iucs = {
+      13: false,
+      12: false,
+      11: false,
+      10: false,
+      9: false,
+      6: false,
+      5: false,
+    };
+    let adjacentUpstreams = [];
+    let subcarriersArray = [];
+    let lowerActual, upperActual;
+
+    function adjacentUpstreamTable(minislotArray, subcarrierSpacing) {
+      let html = `<div class="btn-toolbar justify-content-between" role="toolbar" aria-label="Toolbar with button groups">
+          <div class="input-group" role="group" aria-label="First group">
+            <div class="input-group-text" id="btnGroupAddon2">Frequency</div>
+            <input type="text" id="atdmaFrequency" style="width: 6em;" />
+            <div class="input-group-text" id="btnGroupAddon2">Width</div>
+            <select id="atdmaChannelWidth">
+              <option value="6400000">6.4 MHz</option>
+              <option value="3200000">3.2 MHz</option>
+              <option value="1600000">1.6 MHz</option>
+              <option value="800000">800 KHz</option>
+            </select>
+            <div class="input-group-text" id="btnGroupAddon2">Mod</div>
+            <select id="atdmaModulation">
+              <option>64qam</option>
+              <option>32qam</option>
+              <option>16qam</option>
+              <option>qpsk</option>
+            </select>
+            <div class="input-group-text" id="btnGroupAddon2">RxPower</div>
+            <input type="text" style="width: 2em;" id="atdmaRxPower" value="0" />
+          </div>
+          <div class="input-group">
+            <button id="atdmaAdd" disabled="true">Add ATDMA</button>
+          </div>
+        </div>
+        <table class="table table-sm table-hover table-bordered" style="width:100%;">
+          <thead>
+            <tr>
+              <th scope="col" style="width: 20%;">Frequency</th>
+              <th scope="col" style="width: 20%;">Channel Width</th>
+              <th scope="col" style="width: 20%;">Modulation</th>
+              <th scope="col" style="width: 20%;">Rx Power</th>
+              <th scope="col" style="width: 20%;">Delete</th>
+            </tr>
+          </thead>
+        </table>
+        <div style="overflow-y:scroll;overflow-x:hidden;height:15em;width:100%;">
+        <table class="table table-sm table-hover table-bordered" style="width:100%;">`;
+      adjacentUpstreams.sort(compareCenterFrequencies);
+      adjacentUpstreams.forEach((upstream, index) => {
+        html += `<tr>
+          <td>${upstream.centerFrequency}</td>
+          <td>${upstream.channelWidth}</td>
+          <td>${upstream.modulation}</td>
+          <td>${upstream.rxPower}</td>
+          <td><button onclick="delete adjacentUpstreams[${index}];adjacentUpstreamTable(${JSON.stringify(minislotArray).replace(/"/g, "'")}, ${subcarrierSpacing});">Delete</button></td>
+        </tr>`;
+      });
+      html += `</table>`;
+      $('#adjacentUpstreams').html(html);
+      $('#atdmaFrequency').change(() => {
+        if ($('#atdmaFrequency').val() !== "" && $('#atdmaRxPower').val() !== "") {
+          $('#atdmaAdd').prop('disabled', false);
+
+        } else {
+          $('#atdmaAdd').prop('disabled', true);
+        }
+      });
+      $('#atdmaRxPower').change(() => {
+        if ($('#atdmaFrequency').val() !== "" && $('#atdmaRxPower').val() !== "") {
+          $('#atdmaAdd').prop('disabled', false);
+
+        } else {
+          $('#atdmaAdd').prop('disabled', true);
+        }
+      });
+      $('#atdmaAdd').click(() => {
+        let frequency = parseInt($('#atdmaFrequency').val(), 10);
+        let channelWidth = parseInt($('#atdmaChannelWidth').val(), 10);
+        adjacentUpstreams.push({
+          centerFrequency: frequency,
+          startFrequency: frequency - (channelWidth / 2),
+          endFrequency: frequency + (channelWidth / 2),
+          channelWidth: channelWidth,
+          modulation: $('#atdmaModulation').val(),
+          rxPower: parseInt($('#atdmaRxPower').val(), 10),
+          type: 'atdma'
+        });
+        adjacentUpstreamTable(minislotArray, subcarrierSpacing);
+      });
+      tafdmVisualization(minislotArray, subcarrierSpacing);
+    }
+
+    function compareCenterFrequencies(a, b) {
+      return a.centerFrequency - b.centerFrequency;
+    }
+
+    function tafdmVisualization(minislotArray, subcarrierSpacing, guardband = 'Regular') {
+      let graphObj = [
+        ["Frequency", "Non Overlapping OFDMA Minislots", 'Overlapping OFDMA Minislots', 'Adjacent ATDMA Channels', "Guardband", 'TaFDM Scheduler', "Groups", {
+          role: "annotation"
+        }]
+      ];
+      let ofdmaRxPower = parseInt($('#ofdmaRxPower').val(), 10);
+
+
+      let gbButtonHtml = `<div class="btn-toolbar justify-content-between" role="toolbar" aria-label="Toolbar with button groups">
+          <div class="btn-group" role="group" aria-label="First group"><label><b>Casa Guardband Type&nbsp;</b></label>
+          <button type="button" id="regularGuardband" onclick='tafdmVisualization(${JSON.stringify(minislotArray)}, ${JSON.stringify(subcarrierSpacing)}, "Regular");' class="btn btn-outline-${(guardband === 'Regular') ? 'primary active' : 'secondary'}">Regular</button>
+          <button type="button" id="alternateGuardband" onclick='tafdmVisualization(${JSON.stringify(minislotArray)}, ${JSON.stringify(subcarrierSpacing)}, "Alternate");' class="btn btn-outline-${(guardband === 'Alternate') ? 'primary active' : 'secondary'}">Alternate</button>
+          </div></div>
+          `;
+      $('#tafdmGuardband').html(gbButtonHtml);
+      // TAFDM Calculation
+      let guardbandDataB = [];
+      let guardbandDataA = [];
+      let centerFrequency = minislotArray[0].startFrequency + ((minislotArray[minislotArray.length - 1].endFrequency - minislotArray[0].startFrequency) / 2);
+      let tafdmGuardbandA = false;
+      let tafdmGuardbandB = false;
+      // lower edge
+      let lowerGuardbandNeeded = false;
+      let upperGuardbandNeeded = false;
+      // Unusable Region
+      let lowerUnusable = centerFrequency;
+      let upperUnusable = centerFrequency;
+      let firstMinislotOverlapping, lastMinislotOverlapping;
+      let upstreamOverlapping = false;
+      adjacentUpstreams.sort(compareCenterFrequencies);
+      // Add Current OFDMA Channel
+      minislotArray.forEach((minislot, index) => {
+
+        minislot.overlapping = adjacentUpstreams.some((upstream) => {
+          let overlapping = (minislot.startFrequency >= upstream.startFrequency && minislot.endFrequency < upstream.endFrequency) || (minislot.startFrequency < upstream.startFrequency && minislot.endFrequency >= upstream.startFrequency) || (minislot.startFrequency < upstream.endFrequency && minislot.endFrequency >= upstream.endFrequency);
+          if (firstMinislotOverlapping === undefined) {
+            lowerGuardbandNeeded = upstream;
+          }
+          if (overlapping) {
+            upstreamOverlapping = true;
+          }
+          upperGuardbandNeeded = upstream;
+          return overlapping;
+        });
+        let startBottom, startTop, endBottom, endTop;
+        if (minislot.overlapping) {
+          if (firstMinislotOverlapping === undefined) {
+            firstMinislotOverlapping = index;
+          }
+          lastMinislotOverlapping = index;
+          startBottom = [minislot.startFrequency / 1000000, null, 0, null, null, null, null, null];
+          startTop = [minislot.startFrequency / 1000000, null, 40 /*+ ofdmaRxPower*/, null, null, null, null, null];
+          endBottom = [minislot.endFrequency / 1000000, null, 0, null, null, null, null, null];
+          endTop = [minislot.endFrequency / 1000000, null, 40 /*+ ofdmaRxPower*/, null, null, null, null, null];
+        } else {
+          startBottom = [minislot.startFrequency / 1000000, 0, null, null, null, null, null, null];
+          startTop = [minislot.startFrequency / 1000000, 40 /*+ ofdmaRxPower*/, null, null, null, null, null, null];
+          endBottom = [minislot.endFrequency / 1000000, 0, null, null, null, null, null, null];
+          endTop = [minislot.endFrequency / 1000000, 40 /*+ ofdmaRxPower*/, null, null, null, null, null, null];
+        }
+
+
+        graphObj.push(startBottom);
+        graphObj.push(startTop);
+        graphObj.push(endTop);
+        graphObj.push(endBottom);
+      });
+      // if overlapping upstreams
+      if (upstreamOverlapping) {
+        if (Math.abs(minislotArray[0].startFrequency - lowerGuardbandNeeded.startFrequency) >= Math.abs(minislotArray[minislotArray.length - 1].endFrequency - upperGuardbandNeeded.endFrequency)) {
+          upperGuardbandNeeded = lowerGuardbandNeeded;
+          lowerGuardbandNeeded = undefined;
+
+        } else {
+          lowerGuardbandNeeded = upperGuardbandNeeded;
+          upperGuardbandNeeded = undefined;
+        }
+      } else {
+        // no overlapping UPSTREAMS
+        let closestOnUpperEdge = adjacentUpstreams.reduce((accumulator, upstream) => {
+          let distance = upstream.startFrequency - minislotArray[minislotArray.length - 1].endFrequency;
+          if (distance < accumulator) {
+            accumulator = distance;
+          }
+          return accumulator;
+        }, Infinity);
+        let closestOnLowerEdge = adjacentUpstreams.reduce((accumulator, upstream) => {
+          let distance = minislotArray[0].startFrequency - upstream.endFrequency;
+          if (distance < accumulator) {
+            accumulator = distance;
+          }
+          return accumulator;
+        }, Infinity);
+        //console.log(closestOnLowerEdge, closestOnUpperEdge);
+        if (isFinite(closestOnUpperEdge) && Math.abs(closestOnLowerEdge) > Math.abs(closestOnUpperEdge)) {
+          // upper edge 
+          upperGuardbandNeeded = adjacentUpstreams.reduce((accumulator, upstream) => {
+            if (accumulator === undefined) {
+              accumulator = upstream;
+            } else if (upstream.centerFrequency < accumulator.centerFrequency) {
+              accumulator = upstream;
+            }
+            return accumulator;
+          }, undefined);
+          lowerGuardbandNeeded = undefined;
+        } else {
+          lowerGuardbandNeeded = adjacentUpstreams.reduce((accumulator, upstream) => {
+            if (accumulator === undefined) {
+              accumulator = upstream;
+            } else if (upstream.centerFrequency > accumulator.centerFrequency) {
+              accumulator = upstream;
+            }
+            return accumulator;
+          }, undefined);
+          upperGuardbandNeeded = undefined;
+        }
+      }
+      // Adjacent ATDMAs
+
+      adjacentUpstreams.forEach((upstream) => {
+        if (upstream.type === "atdma") {
+          /*if (lowerGuardbandNeeded === false &&  upstream.centerFrequency < centerFrequency) {
+            lowerGuardbandNeeded = upstream;
+          } else if ( lowerGuardbandNeeded && lowerGuardbandNeeded.centerFrequency < upstream.centerFrequency && upstream.centerFrequency < centerFrequency) {
+            lowerGuardbandNeeded = upstream;
+          }
+          if (upperGuardbandNeeded === false &&  upstream.centerFrequency >= centerFrequency) {
+            upperGuardbandNeeded = upstream;
+          } else if ( upperGuardbandNeeded && upperGuardbandNeeded.centerFrequency > upstream.centerFrequency & upstream.centerFrequency > centerFrequency) {
+            upperGuardbandNeeded = upstream;
+          }*/
+          if (upstream.startFrequency < lowerUnusable) {
+            lowerUnusable = upstream.startFrequency;
+          }
+          if (upstream.endFrequency > upperUnusable) {
+            upperUnusable = upstream.endFrequency;
+          }
+          let lower = new Array(7).fill(null);
+          let haystackLower = new Array(7).fill(null);
+          let haystackUpper = new Array(7).fill(null);
+          let upper = new Array(7).fill(null);
+          lower[2] = 0;
+          upper[2] = 0;
+          haystackLower[2] = -10 /*+ upstream.rxPower*/;
+          haystackUpper[2] = -10 /*+ upstream.rxPower*/;
+          graphObj.push([upstream.centerFrequency / 1000000 - ((upstream.channelWidth / 1000000) / 2)].concat(lower));
+          graphObj.push([upstream.centerFrequency / 1000000 - ((upstream.channelWidth / 1000000) / 2) + .2].concat(haystackLower));
+          graphObj.push([upstream.centerFrequency / 1000000 + ((upstream.channelWidth / 1000000) / 2) - .2].concat(haystackUpper));
+          graphObj.push([upstream.centerFrequency / 1000000 + ((upstream.channelWidth / 1000000) / 2)].concat(upper));
+          graphObj.push([upstream.centerFrequency / 1000000, null, null, null, null, null, -10, `ATDMA  ${(upstream.channelWidth / 1000000)} MHz Wide`]);
+        }
+      });
+      //console.log(graphObj);
+
+      let iucNumbers = Object.getOwnPropertyNames(iucs);
+      let ofdmaRxMerTarget = iucNumbers.reduce((accumulator, iucNumber) => {
+        if (iucs[iucNumber]) {
+          return accumulator += iucs[iucNumber].reduce((accumulator2, minislot) => {
+            return accumulator2 += modulationLookup[minislot.modulation];
+          }, 0) / iucs[iucNumber].length;
+        } else {
+          return accumulator;
+        }
+      }, 0);
+      let gb;
+      if (lowerGuardbandNeeded) {
+        //console.log(centerFrequency, minislotArray[0].startFrequency, minislotArray[minislotArray.length-1].endFrequency, subcarrierSpacing, ofdmaRxPower, ofdmaRxMerTarget, lowerGuardbandNeeded, parseInt($('#cyclicPrefix').val(),10));
+        gb = calculateGuardband(centerFrequency, minislotArray[0].startFrequency, minislotArray[minislotArray.length - 1].endFrequency, subcarrierSpacing, ofdmaRxPower, ofdmaRxMerTarget, lowerGuardbandNeeded, parseInt($('#cyclicPrefix').val(), 10));
+        //console.log('lowerGuardband', lowerGuardbandNeeded, gb, minislotArray);
+
+        if (guardband === 'Regular') {
+          //console.log(lowerGuardbandNeeded.endFrequency, gb.guardbandA);
+          graphObj.push([lowerGuardbandNeeded.endFrequency / 1000000, null, null, null, 0, null, null, null]);
+          graphObj.push([lowerGuardbandNeeded.endFrequency / 1000000, null, null, null, 50, null, null, null]);
+          graphObj.push([(lowerGuardbandNeeded.endFrequency + gb.guardbandA) / 1000000, null, null, null, 50, null, null, null]);
+          graphObj.push([(lowerGuardbandNeeded.endFrequency + gb.guardbandA) / 1000000, null, null, null, 0, null, null, null]);
+          graphObj.push([(lowerGuardbandNeeded.endFrequency + (gb.guardbandA / 2)) / 1000000, null, null, null, null, null, 50, `Guardband ${gb.guardbandA / 1000000} MHz`]);
+        } else {
+          graphObj.push([lowerGuardbandNeeded.endFrequency / 1000000, null, null, null, 0, null, null, null]);
+          graphObj.push([lowerGuardbandNeeded.endFrequency / 1000000, null, null, null, 50, null, null, null]);
+          graphObj.push([(lowerGuardbandNeeded.endFrequency + gb.guardbandB) / 1000000, null, null, null, 50, null, null, null]);
+          graphObj.push([(lowerGuardbandNeeded.endFrequency + gb.guardbandB) / 1000000, null, null, null, 0, null, null, null]);
+          graphObj.push([(lowerGuardbandNeeded.endFrequency + (gb.guardbandB / 2)) / 1000000, null, null, null, null, null, 50, `Guardband ${gb.guardbandB / 1000000} MHz`]);
+        }
+
+        // add unusable if needed
+        if (upstreamOverlapping && minislotArray[0].startFrequency < lowerGuardbandNeeded.endFrequency) {
+          /*graphObj.push([minislotArray[0].startFrequency / 1000000, null, null, null, null, 40, null, null]);
+          graphObj.push([minislotArray[0].startFrequency / 1000000, null, null, null, null, 50, null, null]);
+          graphObj.push([lowerUnusable / 1000000, null, null, null, null, 50, null, null]);
+          graphObj.push([lowerUnusable / 1000000, null, null, null, null, 40, null, null]);*/
+          graphObj.push([minislotArray[0].startFrequency / 1000000, null, null, null, null, 0, null, null]);
+          graphObj.push([minislotArray[0].startFrequency / 1000000, null, null, null, null, 60, null, null]);
+          graphObj.push([lowerGuardbandNeeded.endFrequency / 1000000, null, null, null, null, 60, null, null]);
+          graphObj.push([lowerGuardbandNeeded.endFrequency / 1000000, null, null, null, null, 0, null, null]);
+          //console.log(minislotArray[0].startFrequency, (lowerGuardbandNeeded.endFrequency - minislotArray[0].startFrequency));
+          graphObj.push([(minislotArray[0].startFrequency + ((lowerGuardbandNeeded.endFrequency - minislotArray[0].startFrequency) / 2)) / 1000000, null, null, null, null, null, 60, 'TaFDM Scheduler']);
+        }
+      }
+      if (upperGuardbandNeeded) {
+        //console.log(centerFrequency, minislotArray[0].startFrequency, minislotArray[minislotArray.length-1].endFrequency, subcarrierSpacing, ofdmaRxPower, ofdmaRxMerTarget, lowerGuardbandNeeded, parseInt($('#cyclicPrefix').val(),10));
+        gb = calculateGuardband(centerFrequency, minislotArray[0].startFrequency, minislotArray[minislotArray.length - 1].endFrequency, subcarrierSpacing, ofdmaRxPower, ofdmaRxMerTarget, upperGuardbandNeeded, parseInt($('#cyclicPrefix').val(), 10));
+        //console.log('upperGuardband', upperGuardbandNeeded, gb);
+        if (guardband === "Regular") {
+          graphObj.push([upperGuardbandNeeded.startFrequency / 1000000, null, null, null, 0, null, null, null]);
+          graphObj.push([upperGuardbandNeeded.startFrequency / 1000000, null, null, null, 50, null, null, null]);
+          graphObj.push([(upperGuardbandNeeded.startFrequency - gb.guardbandA) / 1000000, null, null, null, 50, null, null, null]);
+          graphObj.push([(upperGuardbandNeeded.startFrequency - gb.guardbandA) / 1000000, null, null, null, 0, null, null, null]);
+          graphObj.push([(upperGuardbandNeeded.startFrequency - (gb.guardbandA / 2)) / 1000000, null, null, null, null, null, 50, `Guardband ${gb.guardbandA / 1000000} MHz`]);
+        } else {
+          graphObj.push([upperGuardbandNeeded.startFrequency / 1000000, null, null, null, 0, null, null, null]);
+          graphObj.push([upperGuardbandNeeded.startFrequency / 1000000, null, null, null, 50, null, null, null]);
+          graphObj.push([(upperGuardbandNeeded.startFrequency - gb.guardbandB) / 1000000, null, null, null, 50, null, null, null]);
+          graphObj.push([(upperGuardbandNeeded.startFrequency - gb.guardbandB) / 1000000, null, null, null, 0, null, null, null]);
+          graphObj.push([(upperGuardbandNeeded.startFrequency - (gb.guardbandB / 2)) / 1000000, null, null, null, null, null, 50, `Guardband ${gb.guardbandB / 1000000} MHz`]);
+        }
+        // add unusable if necessary
+        if (upstreamOverlapping && minislotArray[minislotArray.length - 1].endFrequency > upperGuardbandNeeded.startFrequency) {
+          /*
+          graphObj.push([upperUnusable / 1000000, null, null, null, null, 40, null, null]);
+          graphObj.push([upperUnusable/ 1000000, null, null, null, null, 50, null, null]);
+          graphObj.push([minislotArray[minislotArray.length-1].endFrequency/ 1000000, null, null, null, null, 50, null, null]);
+          graphObj.push([minislotArray[minislotArray.length-1].endFrequency/ 1000000, null, null, null, null, 40, null, null]);*/
+          graphObj.push([upperGuardbandNeeded.startFrequency / 1000000, null, null, null, null, 0, null, null]);
+          graphObj.push([upperGuardbandNeeded.startFrequency / 1000000, null, null, null, null, 60, null, null]);
+          graphObj.push([minislotArray[minislotArray.length - 1].endFrequency / 1000000, null, null, null, null, 60, null, null]);
+          graphObj.push([minislotArray[minislotArray.length - 1].endFrequency / 1000000, null, null, null, null, 0, null, null]);
+          graphObj.push([(upperGuardbandNeeded.startFrequency + ((minislotArray[minislotArray.length - 1].endFrequency - upperGuardbandNeeded.startFrequency) / 2)) / 1000000, null, null, null, null, null, 60, 'TaFDM Scheduler']);
+        }
+      }
+
+      let clone;
+      clone = graphObj.slice(1, graphObj.length);
+      //console.log(lowerGuardbandNeeded, upperGuardbandNeeded);
+      if (!lowerGuardbandNeeded && !upperGuardbandNeeded) {
+        graphObj.push([-1000, null, 0, 0, 0, 0, 0, '']);
+
+      } else {
+        graphObj.push([-1000, null, 0, null, null, 0, 0, '']);
+      }
+      /*
+       ["Frequency", "Non Overlapping OFDMA Minislots", 'Overlapping OFDMA Minislots', 'Adjacent ATDMA Channels', "Guardband", 'TaFDM Scheduler', "Groups", {
+            role: "annotation"
+          }]
+      */
+      clone.sort(compareNumbers);
+      //console.log(graphObj);
+      let data = google.visualization.arrayToDataTable(graphObj, false);
+      let options = {
+        title: `${(firstMinislotOverlapping) ? 'TaFDM Scheduler Active' : (gb && gb[guardband] === true) ? 'TaFDM Scheduler Possibly Active Verify with tafdm-info' : 'TaFDM Scheduler Inactive'}`,
+        annotations: {
+          textStyle: {
+            fontName: 'Calibri',
+            fontSize: 11,
+            bold: true,
+            italic: true,
+            // The color of the text.
+            color: 'black',
+            // The color of the text outline.
+            auraColor: 'white',
+            // The transparency of the text.
+            opacity: 0.8
+          },
+          datum: {
+            stem: {
+              color: "#0099fc",
+              length: 20
+            }
+          },
+        },
+        series: {
+          1: {
+            type: "line",
+            visibleInLegend: (firstMinislotOverlapping !== undefined || lastMinislotOverlapping !== undefined)
+          },
+          2: {
+            type: "area",
+            visibleInLegend: adjacentUpstreams.length > 0
+          },
+          3: {
+            type: "area",
+            visibleInLegend: adjacentUpstreams.length > 0
+          },
+          4: {
+            type: "area",
+            visibleInLegend: adjacentUpstreams.length > 0 && ((upperUnusable < minislotArray[minislotArray.length - 1].endFrequency) || (lowerUnusable > minislotArray[0].startFrequency))
+          },
+
+          5: {
+            type: 'scatter',
+            color: 'transparent',
+            visibleInLegend: false
+          }
+        },
+        hAxis: {
+          title: "Frequency in MHz",
+          viewWindow: {
+            max: clone[clone.length - 1][0] + 1,
+            min: clone[1][0] - 1,
+          },
+          gridlineColor: '#fff',
+        },
+        vAxis: {
+          viewWindow: {
+            min: -10,
+            max: 70
+          },
+          format: 'decimal',
+          gridlineColor: '#fff',
+
+          textPosition: "none"
+        }
+      };
+      var formatNumber = new google.visualization.NumberFormat({
+        fractionDigits: (subcarrierSpacing === 50000) ? 3 : 4
+      });
+      //console.log(options, graphObj);
+      formatNumber.format(data, 0);
+      var chart = new google.visualization.ComboChart(document.getElementById('tafdmVisualization'));
+      chart.draw(data, options);
+      generateConfig(minislotArray, subcarrierSpacing, guardband = 'Regular');
+      psdVisualization()
+    }
+    function psdVisualization() {
+      let graphObj = [
+
+      ];
+      const frequencies = [lowerActual / 1000000, upperActual / 1000000];
+      const pphs = [];
+      let reference;
+      function buildHaystack(startFreq, endFreq, channelWidth, type, pph, rxPower, name) {
+        name = name || "";
+        const centerFrequency = (endFreq - (channelWidth / 2)) / 1000000;
+        startFreq = startFreq / 1000000;
+        endFreq = endFreq / 1000000;
+        let ofdmapph = 0;
+        let atdmapph = 0;
+        if (type === "ofdma") {
+          ofdmapph = pph;
+          reference = Number(pph);
+        }
+        else atdmapph = pph;
+        const baseLabelHeight = (type === "ofdma") ? 30 : (Number(channelWidth) == 6400000) ? 30 : (channelWidth == 3200000) ? 45 : 55;
+        graphObj.push([startFreq, 0, 0, 0, "", 0, "", 0, "", 0, "", reference, "", `Reference PPH ${reference}`]);
+        graphObj.push([startFreq + .45, ofdmapph, atdmapph, 0, "", 0, "", 0, "", 0, "", reference, "", `Reference PPH ${reference}`]);
+        graphObj.push([centerFrequency, ofdmapph, atdmapph, Math.max(ofdmapph, atdmapph), `${Math.max(ofdmapph, atdmapph)}`, baseLabelHeight, `${type.toUpperCase()} ${name}`, baseLabelHeight - 5, `Width: ${channelWidth / 1000000} MHz`, baseLabelHeight - 10, `RX Power: ${rxPower} dBmV`, reference, (type == "ofdma") ? 'Reference Line' : '', `Reference PPH ${reference}`]);
+        graphObj.push([endFreq - .45, ofdmapph, atdmapph, 0, "", 0, "", 0, "", 0, "", reference, "", `Reference PPH ${reference}`]);
+        graphObj.push([endFreq, 0, 0, 0, "", 0, "", 0, "", 0, "", reference, "", `Reference PPH ${reference}`]);
+        pphs.push(pph);
+        frequencies.push(startFreq, endFreq);
+      }
+
+
+      const ofdmaRxPower = parseInt($('#ofdmaRxPower').val())
+      const channelWidth = (upperActual - lowerActual);
+      const ofdmapph = Math.abs(ofdmaRxPower - (10 * Math.log10(1600000 / 1))).toFixed(4);
+      pphs.push(ofdmapph);
+      const centerFreq = (upperActual - (channelWidth / 2)) / 1000000;
+      buildHaystack(lowerActual, upperActual, channelWidth, "ofdma", ofdmapph, ofdmaRxPower, $('#ofdmaInterfaceName').val());
+
+      adjacentUpstreams.forEach((upstream) => {
+        const pph = Math.abs(upstream.rxPower - (10 * Math.log10(upstream.channelWidth / 1))).toFixed(4);
+        buildHaystack(upstream.startFrequency, upstream.endFrequency, upstream.channelWidth, "atdma", pph, upstream.rxPower, upstream.name);
+      });
+      graphObj.unshift([Math.min(...frequencies) - 2, 0, 0, 0, "", 0, "", 0, "", 0, "", reference, "", `Reference PPH ${reference}`]);
+      graphObj.unshift([
+        "Frequency",
+        "OFDMA Channel",
+        'Adjacent ATDMA Channels',
+        "centers",
+        {
+          role: "tooltip"
+        },
+        "centers2",
+        {
+          role: "annotation"
+        },
+        "centers3",
+        {
+          role: "annotation"
+        },
+        "centers4",
+        {
+          role: "annotation"
+        }
+        ,
+        "centers5",
+        {
+          role: "annotation"
+        },
+        {
+          role: "tooltip"
+        }
+      ]);
+      graphObj.push([Math.max(...frequencies) + 2, 0, 0, 0, "", 0, "", 0, "", 0, "", reference, "", `Reference PPH ${reference}`]);
+
+      let data = google.visualization.arrayToDataTable(graphObj, false);
+      let options = {
+        annotations: {
+          textStyle: {
+            fontName: 'Calibri',
+            fontSize: 12,
+            bold: true,
+            italic: true,
+            // The color of the text.
+            color: 'black',
+            // The color of the text outline.
+            auraColor: 'white',
+            // The transparency of the text.
+            opacity: 0.8
+          }
+        },
+        height: "100%",
+        title: "Power Spectral Density",
+        series: {
+          0: {
+            visibleInLegend: true,
+            type: "area"
+          },
+          1: {
+            type: "area"
+          },
+          2: {
+            type: 'scatter',
+            color: 'transparent',
+            visibleInLegend: false
+          },
+          3: {
+            type: 'scatter',
+            color: 'transparent',
+            visibleInLegend: false,
+            annotations: {
+              stem: {
+                color: 'none',
+                length: 5
+              },
+            }
+          },
+          4: {
+            type: 'scatter',
+            color: 'transparent',
+            visibleInLegend: false,
+            annotations: {
+              stem: {
+                color: 'none',
+                length: 5
+              },
+            }
+          },
+          5: {
+            type: 'scatter',
+            color: 'transparent',
+            visibleInLegend: false,
+            annotations: {
+              stem: {
+                color: 'none',
+                length: 5
+              },
+            }
+          },
+          6: {
+            type: 'line',
+            color: 'limegreen',
+            visibleInLegend: false,
+            lineWidth: 4,
+            lineDashStyle: [4, 4],
+            annotations: {
+              stem: {
+                color: 'none',
+                length: 5
+              },
+            }
+          }
+        },
+        hAxis: {
+          title: "Frequency in MHz", viewWindow: {
+            max: Math.max(...frequencies) + 2,
+            min: Math.min(...frequencies) - 2,
+          },
+          gridlineColor: '#fff',
+        },
+        vAxis: {
+          title: "Power per Hz",
+          viewWindow: {
+            min: 0,
+            max: Math.abs(Math.max(...pphs)) + 5
+          },
+          format: 'decimal',
+          //gridlineColor: '#fff',
+        }
+      };
+      var formatNumber = new google.visualization.NumberFormat({
+        fractionDigits: 4
+      });
+      formatNumber.format(data, 0);
+      const container = document.getElementById('psdVisualization')
+      var chart = new google.visualization.ComboChart(container);
+      chart.draw(data, options);
+      google.visualization.events.addListener(chart, 'ready', function () {
+        var observer = new MutationObserver(function () {
+          var labels = container.getElementsByTagName('text');
+          Array.prototype.forEach.call(labels, function (label) {
+            if (label.getAttribute('text-anchor') === 'middle') {
+              if (label.textContent.includes("MHz O") || label.textContent.includes("MHz A")) label.setAttribute('transform', 'rotate(-30, ' + label.getAttribute('x') + ' ' + label.getAttribute('y') + ')');
+            }
+          });
+        });
+        observer.observe(container, {
+          childList: true,
+          subtree: true
+        });
+      });
+    }
+
+    function updateSubcarriersAndMinislots() {
+      let subcarrierSpacing = parseInt($('#subcarrierSpacing').val(), 10);
+      let subcarrierZeroFrequency1 = subcarrierZeroFrequency(parseInt($('#lowerFreq').val(), 10), subcarrierSpacing);
+      //console.log(subcarrierZeroFrequency1);
+      let subcarriers1;
+      try {
+        subcarriers1 = subcarriers(subcarrierSpacing, subcarrierZeroFrequency1, parseInt($('#upperFreq').val(), 10));
+      } catch (e) {
+        alert(e.message);
+      }
+      //console.log(subcarriers1);
+      if (excludedScs) {
+        subcarriers1 = setExclusionBands(subcarriers1, excludedScs);
+      }
+      let scsWithMinislots = generateMinislots(subcarriers1, subcarrierSpacing);
+      //console.log(JSON.stringify(scsWithMinislots, undefined, 2));
+      let subcarriersTable = `<table class="table table-sm table-hover table-bordered" id="subcarrierTable" style="width:100%;"><thead>
+          <tr>
+            <th scope="col" style="width: 7em;">SubCarrier</th>
+            <th scope="col" style="width: 6em;">Start</th>
+            <th scope="col" style="width: 6em;">Center</th>
+            <th scope="col" style="width: 6em;">End</th>
+            <th scope="col" style="width: 7em;">Minislot</th>
+            <th scope="col" style="width: 7em;">Type</th>
+            <th scope="col"><button id="excludeBtn" onclick="updateSubcarriersAndMinislots()">Update Excludes</exclude></th>
+          </tr>
+        </thead></table><table class="table table-sm table-hover table-bordered" style="height:22em;overflow-y:scroll;overflow-x:hidden;display:block;width:100%">`;
+      let lastRowNum, firstDatSc, minislotIncrease;
+      if (subcarrierSpacing === 50000) {
+        firstDatSc = 74;
+        lastRowNum = 73;
+        minislotIncrease = 7;
+      }
+      else {
+        firstDatSc = 148;
+        lastRowNum = 147;
+        minislotIncrease = 15;
+      }
+      let minislotsArray = [];
+      let manualOrAuto = document.getElementById("boundaryType").value;
+      scsWithMinislots.forEach((row, index, array) => {
+        if ((manualOrAuto == "manual" && row.index >= firstDatSc && row.endFrequency <= parseInt($('#upperFreq').val(), 10)) || (manualOrAuto == "auto" && row.index >= firstDatSc && row.centerFrequency <= parseInt($('#upperFreq').val(), 10))) {
+          subcarriersTable += `<tr><td style="width: 7em;">${row.index}</td><td style="width: 6em;">${row.startFrequency}</td><td style="width: 6em;">${row.centerFrequency}</td><td style="width: 6em;">${row.endFrequency}</td><td style="width: 7em;">${(row.minislot !== undefined) ? row.minislot : "n/a"}</td><td style="width: 7em;">${row.type}</td><td  style="width: 12em;"><input type="checkbox" class="exclude" name="exclude" ${(row.type === "excluded") ? 'checked="true"' : ''}/></td></tr>`;
+          lastRowNum++;
+          if (row.minislot !== undefined && array[index + minislotIncrease].minislot === row.minislot) {
+            minislotsArray.push({
+              minislot: row.minislot,
+              startFrequency: row.startFrequency,
+              endFrequency: array[index + minislotIncrease].endFrequency
+            });
+          }
+        }
+      });
+      subcarriersTable += `<tr></tr><tr></tr></table>`;
+      $('#subcarrierTable').html(subcarriersTable);
+      $('#minislots').val(scsWithMinislots.minislots);
+      $('#unusedCarriers').val(scsWithMinislots.unusedCarriers);
+      let lowerFreq = parseInt($('#lowerFreq').val(), 10);
+      let upperFreq = parseInt($('#upperFreq').val(), 10);
+      
+      if (manualOrAuto == "manual" && ((lowerFreq + (subcarrierSpacing / 2)) % subcarrierSpacing !== 0)) {
+        $('#lowerFreqProblem').text('(Lower Frequency + (SubcarrierSpacing /2) must be evenly divisible by subcarrierSpacing)');
+      }
+      else if (manualOrAuto == "auto" && (lowerFreq % subcarrierSpacing !== 0)) {
+        $('#lowerFreqProblem').text('(Lower Center Frequency must be evenly divisible by subcarrierSpacing)');
+      }
+      else {
+        $('#lowerFreqProblem').text('');
+      }
+      if (manualOrAuto == "manual" && lowerFreq != scsWithMinislots[firstDatSc].startFrequency) {
+        $('#lowerActual').text(`Silently-adjusted to ` + scsWithMinislots[firstDatSc].startFrequency);
+      }
+      else if (manualOrAuto == "auto" && lowerFreq != scsWithMinislots[firstDatSc].centerFrequency) {
+        $('#lowerActual').text(`Silently-adjusted to ` + scsWithMinislots[firstDatSc].centerFrequency);
+      }
+      else {
+        $('#lowerActual').text('');
+      }
+      lowerActual = scsWithMinislots[firstDatSc].startFrequency;
+      if (manualOrAuto == "manual" && ((upperFreq - (subcarrierSpacing / 2)) % subcarrierSpacing !== 0)) {
+        $('#upperFreqProblem').text('(Upper Frequency - (SubcarrierSpacing /2) must be evenly divisible by subcarrierSpacing)');
+      }
+      else if (manualOrAuto == "auto" && (upperFreq % subcarrierSpacing !== 0)) {
+        $('#upperFreqProblem').text('(Upper Center Frequency must be evenly divisible by subcarrierSpacing)');
+      }
+      else {
+        $('#upperFreqProblem').text('');
+      }
+      if (manualOrAuto == "manual" && upperFreq != scsWithMinislots[lastRowNum].endFrequency) {
+        $('#upperActual').text(`Silently-adjusted to ` + scsWithMinislots[lastRowNum].endFrequency);
+      }
+      else if (manualOrAuto == "auto" && upperFreq != scsWithMinislots[lastRowNum].centerFrequency) {
+        $('#upperActual').text(`Silently-adjusted to ` + scsWithMinislots[lastRowNum].centerFrequency);
+      }
+      else {
+        $('#upperActual').text('');
+      }
+      upperActual = scsWithMinislots[lastRowNum].endFrequency;
+      // setup exclusions
+      $('[name=exclude]').click(function () {
+        var values = new Array();
+        $.each($("input[name='exclude']:checked"), function () {
+          var data = $(this).parents('tr:eq(0)');
+          values.push(parseInt($(data).find('td:eq(0)').text(), 10));
+        });
+        excludedScs = values;
+      });
+      minislotVisualization(scsWithMinislots, scsWithMinislots[firstDatSc].startFrequency, scsWithMinislots[lastRowNum].endFrequency, subcarrierSpacing);
+
+      iucs = {
+        13: false,
+        12: false,
+        11: false,
+        10: false,
+        9: false,
+        6: false,
+        5: false,
+      }
+      iucs[13] = applyModulationPilot(minislotsArray.slice(0), "64qam", (subcarrierSpacing === 50000) ? 2 : 6, 32, 32);
+      subcarriersArray = scsWithMinislots;
+      minislotTable(13, subcarrierSpacing);
+
+    }
+
+    function applyModulationPilot(array, modulation, pilotPattern, initialRanging, fineRanging) {
+      array.forEach((item) => {
+        item.modulation = modulation;
+        item.pilotPattern = pilotPattern;
+      });
+      array.modulation = modulation;
+      array.pilotPattern = pilotPattern;
+      array.initialRanging = initialRanging;
+      array.fineRanging = fineRanging;
+      return array;
+    }
+
+    function minislotTable(selectedIuc, subcarrierSpacing) {
+      let minislotArray = iucs[selectedIuc];
+      // Build Header
+      let iucNumbers = Object.getOwnPropertyNames(iucs).sort((a, b) => { return b - a; });
+      let html = `<div class="btn-toolbar justify-content-between" role="toolbar" aria-label="Toolbar with button groups">
+          <div class="input-group">
+            <button ${(iucNumbers.reduce((accumulator, currentValue) => {
+        if (iucs[currentValue]) {
+          return accumulator + 1;
+        }
+        return accumulator;
+      }, 0) > 4) ? 'disabled="true"' : ''} onclick="iucs[$('#newIuc').val()] = applyModulationPilot(JSON.parse(JSON.stringify(iucs[13].slice(0))), $('#minislotModulation').val(), $('#minislotPilotPattern').val(), $('#minislotInitialRanging').val(), $('#minislotFineRanging').val());minislotTable($('#newIuc').val(),${subcarrierSpacing} )">Add</button>
+            <select id="newIuc">
+            ${iucNumbers.reduce((accumulator, number) => {
+        if (!iucs[number]) {
+          return accumulator += `<option>${number}</option>`;
+        }
+        return accumulator;
+      }, '')}
+            </select>
+            
+          </div>
+          <div class="input-group" role="group" aria-label="First group">
+            <div class="input-group-text" id="btnGroupAddon2">Cyclic Prefix</div>
+            <select class="form-control" id="cyclicPrefix" onchange="cp1=this.value;minislotTable(${selectedIuc}, ${subcarrierSpacing});">
+              ${[640, 512, 384, 320, 256, 224, 192, 160, 128, 96].reduce((accumulator, item) => {
+        return accumulator += `<option ${(cp1 == item) ? 'selected="true"' : ''}>${item}</option>`;
+      }, '')}
+            </select>
+            <div class="input-group-text" id="btnGroupAddon2">Rolloff Period</div>
+            <select class="form-control" id="rolloffPeriod">
+              ${[224, 192, 160, 128, 96, 64, 32, 0].reduce((accumulator, item) => {
+        if (item < cp1) {
+          if (rp1 > cp1) {
+            rp1 = item;
+          }
+          return accumulator += `<option ${(rp1 == item) ? 'selected="true"' : ''}>${item}</ option>`;
+        }
+        return accumulator;
+      }, '')}
+            </select>
+          <div class="input-group-text" id="btnGroupAddon3">Initial</div>
+            <select id="minislotInitialRanging">
+              ${[64, 32].reduce((accumulator, item) => {
+        return accumulator += `<option ${(minislotArray.initialRanging == item) ? 'selected="true"' : ''}>${item}</option>`;
+      }, '')}
+            </select>
+            <div class="input-group-text" id="btnGroupAddon3">Fine</div>
+            
+            <select id="minislotFineRanging">
+              ${[64, 32].reduce((accumulator, item) => {
+        return accumulator += `<option ${(minislotArray.fineRanging == item) ? 'selected="true"' : ''}>${item}</option>`;
+      }, '')}
+            </select>
+            <div class="input-group-text" id="btnGroupAddon3">Symbols</div>
+            <input type="text" disabled="true" id="symbolsPerFrame" style="width: 2em;" value="${(minislotArray.initialRanging == 64) ? 11 : (minislotArray.fineRanging == 64) ? 15 : 16}" />
+          </div>
+          </div></div><div class="btn-toolbar justify-content-between" role="toolbar" aria-label="Toolbar with button groups">
+          <div class="btn-group" role="group" aria-label="First group">`;
+
+      iucNumbers.forEach((iucNumber) => {
+        if (iucs[iucNumber]) {
+          html += `<button type="button" onclick="minislotTable(${iucNumber}, ${subcarrierSpacing});" class="btn btn-outline-${(iucNumber == selectedIuc) ? 'primary active' : 'secondary'}">${iucNumber}</button>`;
+        }
+      });
+
+      //  <button type="button" class="btn btn-outline-secondary">1</button>
+      //
+      html += `</div><div class="btn-group" role="group" aria-label="Second group">
+        <button ${(selectedIuc == 13) ? 'disabled="true"' : ''} onclick="iucs[${selectedIuc}] = false;minislotTable (13, ${subcarrierSpacing})">Delete</button>
+            <button  onclick="iucs[${selectedIuc}] = applyModulationPilot(JSON.parse(JSON.stringify(iucs[13].slice(0))), $('#minislotModulation').val(), $('#minislotPilotPattern').val(), $('#minislotInitialRanging').val(), $('#minislotFineRanging').val());minislotTable(${selectedIuc},${subcarrierSpacing} )">Update</button>
+            
+            <div class="input-group-text" id="btnGroupAddon2">Mod</div>
+            <select id="minislotModulation">
+              <option ${(minislotArray.modulation === 'qpsk') ? 'selected="true"' : ''}>qpsk</option>
+              <option ${(minislotArray.modulation === '8qam') ? 'selected="true"' : ''}>8qam</option>
+              <option ${(minislotArray.modulation === '16qam') ? 'selected="true"' : ''}>16qam</option>
+              <option ${(minislotArray.modulation === '32qam') ? 'selected="true"' : ''}>32qam</option>
+              <option ${(minislotArray.modulation === '64qam') ? 'selected="true"' : ''}>64qam</option>
+              <option ${(minislotArray.modulation === '128qam') ? 'selected="true"' : ''}>128qam</option>
+              <option ${(minislotArray.modulation === '256qam') ? 'selected="true"' : ''}>256qam</option>
+              <option ${(minislotArray.modulation === '512qam') ? 'selected="true"' : ''}>512qam</option>
+              <option ${(minislotArray.modulation === '1024qam') ? 'selected="true"' : ''}>1024qam</option>
+			  <option ${(minislotArray.modulation === '2048qam') ? 'selected="true"' : ''}>2048qam</option>
+			  <option ${(minislotArray.modulation === '4096qam') ? 'selected="true"' : ''}>4096qam</option>
+            </select>
+            <div class="input-group-text" id="btnGroupAddon3">Pilot</div>
+            <select id="minislotPilotPattern">`;
+      if (subcarrierSpacing === 50000) {
+        html += `
+              <option ${(minislotArray.pilotPattern == 1) ? 'selected="true"' : ''}>1</option>
+              <option ${(minislotArray.pilotPattern == 2) ? 'selected="true"' : ''}>2</option>
+              <option ${(minislotArray.pilotPattern == 3) ? 'selected="true"' : ''}>3</option>
+              <option ${(minislotArray.pilotPattern == 4) ? 'selected="true"' : ''}>4</option>`;
+      }
+      else {
+        html += `  
+          
+              <option ${(minislotArray.pilotPattern == 5) ? 'selected="true"' : ''}>5</option>
+              <option ${(minislotArray.pilotPattern == 6) ? 'selected="true"' : ''}>6</option>
+              <option ${(minislotArray.pilotPattern == 7) ? 'selected="true"' : ''}>7</option>
+              <option ${(minislotArray.pilotPattern == 8) ? 'selected="true"' : ''}>8</option>
+              <option ${(minislotArray.pilotPattern == 9) ? 'selected="true"' : ''}>9</option>
+              <option ${(minislotArray.pilotPattern == 10) ? 'selected="true"' : ''}>10</option>
+              <option ${(minislotArray.pilotPattern == 11) ? 'selected="true"' : ''}>11</option>`;
+      }
+      html += `</select>
+            
+          `;
+      $('#minislotTable').html(html);
+      html = `<table class="table table-sm table-hover table-bordered" id="subcarrierTable" style="width:100%;">
+          <thead>
+            <tr>
+              <th scope="col" style="width: 17%;">Minislot</th>
+              <th scope="col" style="width: 17%;">Start</th>
+              <th scope="col" style="width: 17%;">End</th>
+              <th scope="col" style="width: 17%;">Modulation</th>
+              <th scope="col" style="width: 17%;">Pilot Pattern</th>
+              <th scope="col" style="width: 15%;"><button onclick="updateIndividualMinislots(${selectedIuc});minislotTable (${selectedIuc}, ${subcarrierSpacing})">Update Minislots</button><br />Bandwidth:<br /><span id="totalBw"></span></th>
+            </tr>
+          </thead>
+        </table>
+        <div style="overflow-y:scroll;overflow-x:hidden;height:13em;width:100%;">
+        <table class="table table-sm table-hover table-bordered" style="width:100%;">`;
+      let duration = symbolDurationLookup[subcarrierSpacing];
+      let cp = cpLookup[$('#cyclicPrefix').val()];
+      let rp = rpLookup[$('#rolloffPeriod').val()];
+      let symbolsPerSecond = 1 / (duration + cp + rp);
+      //(symbolsPerSecond * (minislotsBandwidth/numSymbols) /1000000).toFixed(2)
+      let symbolsPerFrame = parseInt((minislotArray.initialRanging == 64) ? 11 : (minislotArray.fineRanging == 64) ? 15 : 16, 10);
+      let totalbw = 0;
+      minislotArray.forEach((row) => {
+
+        let bw = parseFloat((symbolsPerSecond * (minislotCapacity(symbolsPerFrame, bandwidthModulationLookup[row.modulation], row.pilotPattern) / symbolsPerFrame) / 1000000).toFixed(2));
+        //console.log(symbolsPerSecond, symbolsPerFrame, bandwidthModulationLookup[row.modulation], row.pilotPattern, symbolsPerFrame);
+        totalbw += bw;
+        html += `<tr>
+                    <td scope="col" style="width: 17.4%">${row.minislot}</td>
+                    <td scope="col" style="width: 17.4%;">${row.startFrequency}</td>
+                    <td scope="col" style="width: 17.4%;">${row.endFrequency}</td>
+                    <td scope="col" style="width: 17.4%;"><select name="minislotModulationInd">${['qpsk', '8qam', '16qam', '32qam', '64qam', '128qam', '256qam', '512qam', '1024qam', '2048qam', '4096qam'].reduce((accumulator, mod) => {
+          return accumulator += `<option ${(mod === row.modulation) ? 'selected="true"' : ''}>${mod}</option>`;
+        }, '')}</select></td>
+                    <td scope="col" style="width: 17.4%;"><select name="minislotPilotInd">${((subcarrierSpacing === 50000) ? [1, 2, 3, 4] : [5, 6, 7, 8, 9, 10, 11]).reduce((accumulator, pilotPattern) => {
+          return accumulator += `<option ${(pilotPattern == row.pilotPattern) ? 'selected="true"' : ''}>${pilotPattern}</option>`;
+        }, '')}</select></td>
+                    <td scope="col" style="width: 13%;">${bw} Mbps</td></tr>`;
+
+      });
+      html += `</table></div>`;
+      $('#minislotTable').append(html);
+      $('#rolloffPeriod').change(() => {
+        rp1 = parseInt($('#rolloffPeriod').val(), 10);
+        minislotTable(selectedIuc, subcarrierSpacing);
+      });
+      $('#totalBw').text(totalbw.toFixed(2) + " Mbps");
+      minislotRxMERVisualization(iucs[selectedIuc], subcarrierSpacing);
+      adjacentUpstreamTable(minislotArray, subcarrierSpacing);
+    }
+
+    function minislotRxMERVisualization(minislotArray, subcarrierSpacing) {
+      let graphObj = [
+        ["Frequency", "RxMER"]
+      ];
+      let rxMerTarget = 0;
+      minislotArray.forEach((minislot) => {
+        let startBottom = [minislot.startFrequency / 1000000, 0];
+        let startTop = [minislot.startFrequency / 1000000, modulationLookup[minislot.modulation]];
+        let endBottom = [minislot.endFrequency / 1000000, 0];
+        let endTop = [minislot.endFrequency / 1000000, modulationLookup[minislot.modulation]];
+        minislot.rxMerTarget = modulationLookup[minislot.modulation];
+        rxMerTarget += minislot.rxMerTarget;
+        graphObj.push(startBottom);
+        graphObj.push(startTop);
+        graphObj.push(endTop);
+        graphObj.push(endBottom);
+      });
+      minislotArray.rxMerTarget = rxMerTarget / minislotArray.length;
+
+
+      let clone;
+      clone = graphObj.slice(1);
+      clone.sort(compareNumbers);
+      let data = google.visualization.arrayToDataTable(graphObj, false);
+      let options = {
+        title: "Minislots Minimum RxMER",
+        series: {
+          1: {
+            visibleInLegend: false
+          }
+        },
+        hAxis: {
+          title: "Frequency in MHz",
+          viewWindow: {
+            max: clone[clone.length - 1][0] + 1,
+            min: clone[1][0] - 1,
+          },
+          gridlineColor: '#fff',
+        },
+        vAxis: {
+          title: "RxMER in dB",
+          viewWindow: {
+            min: 0,
+            max: 50
+          },
+          format: 'decimal',
+          //gridlineColor: '#fff',
+        }
+      };
+      var formatNumber = new google.visualization.NumberFormat({
+        fractionDigits: (subcarrierSpacing === 50000) ? 3 : 4
+      });
+      formatNumber.format(data, 0);
+      var chart = new google.visualization.AreaChart(document.getElementById('minislotRxMerVisualization'));
+      chart.draw(data, options);
+    }
+
+    function updateIndividualMinislots(selectedIuc) {
+      let iuc = iucs[selectedIuc];
+      $.each($("select[name='minislotModulationInd']"), function () {
+
+        var data = $(this).parents('tr:eq(0)');
+        iuc[parseInt($(data).find('td:eq(0)').text(), 10)].modulation = $(this).val();
+      });
+      $.each($("select[name='minislotPilotInd']"), function () {
+        var data = $(this).parents('tr:eq(0)');
+        iuc[parseInt($(data).find('td:eq(0)').text(), 10)].pilotPattern = $(this).val();
+      });
+    }
+
+    function minislotVisualization(subcarriers, start, end, subcarrierSpacing) {
+      let graphObj = [
+        ["Frequency", "Minislots", {'type': 'string', 'role': 'tooltip', 'p': {'html': true}}, "Unused Subcarriers", {'type': 'string', 'role': 'tooltip', 'p': {'html': true}}, 'Excluded Subcarriers', {'type': 'string', 'role': 'tooltip', 'p': {'html': true}}]
+      ];
+      let unusedCount = 0,
+        excludedCount = 0,
+        dataCount = 0;;
+      let scIncrease;
+      if (subcarrierSpacing === 50000) {
+        scIncrease = 7;
+      }
+      else {
+        scIncrease = 15;
+      }
+      for (let x = 0; x < subcarriers.length; x++) {
+        let subcarrier = subcarriers[x];
+        if (subcarrier.startFrequency >= start && subcarrier.endFrequency <= end) {
+          let startBottom = [subcarrier.startFrequency / 1000000, null, ``, null, ``, null, ``];
+          let startTop = [subcarrier.startFrequency / 1000000, null, ``, null, ``, null, ``];
+          let endBottom = [subcarrier.endFrequency / 1000000, null, ``, null, ``, null, ``];
+          let endTop = [subcarrier.endFrequency / 1000000, null, ``, null, ``, null, ``];
+          switch (subcarrier.type) {
+            case 'data':
+              startBottom = [subcarrier.startFrequency / 1000000, 0, `<div style="width:10em;"><div>Minislot: ${subcarrier.minislot}</div><div>Start&nbsp;Freq:&nbsp;${subcarrier.startFrequency/1000000}&nbsp;MHz</div><div>End Freq: ${subcarrier.endFrequency / 1000000} MHz</div></div>`, null, ``, null, ``];
+              startTop = [subcarrier.startFrequency / 1000000, 2, `<div style="width:10em;"><div>Minislot: ${subcarrier.minislot}</div><div>Start&nbsp;Freq:&nbsp;${subcarrier.startFrequency/1000000}&nbsp;MHz</div><div>End Freq: ${subcarrier.endFrequency / 1000000} MHz</div></div>`, null, ``, null, ``];
+              endTop = [subcarriers[x + scIncrease].endFrequency / 1000000, 2, `<div style="width:10em;"><div>Minislot: ${subcarrier.minislot}</div><div>Start&nbsp;Freq:&nbsp;${subcarrier.startFrequency/1000000}&nbsp;MHz</div><div>End Freq: ${subcarrier.endFrequency / 1000000} MHz</div></div>`, null, ``, null, ``];
+              endBottom = [subcarriers[x + scIncrease].endFrequency / 1000000, 0, `<div style="width:10em;"><div>Minislot: ${subcarrier.minislot}</div><div>Start&nbsp;Freq:&nbsp;${subcarrier.startFrequency/1000000}&nbsp;MHz</div><div>End Freq: ${subcarrier.endFrequency / 1000000} MHz</div></div>`, null, ``, null, ``];
+              x += scIncrease
+              break;
+            case 'unused':
+              startBottom[3] = 0;
+              startBottom[4] =`<div style="width:10em;"><div>Unused Subcarrier</div><div>Start Freq: ${subcarrier.startFrequency/1000000}&nbsp;MHz</div><div>End Freq: ${subcarrier.endFrequency / 1000000} MHz</div><div>`;
+              startTop[3] = 2.5;
+              startTop[4] =`<div style="width:10em;"><div>Unused Subcarrier</div><div>Start Freq: ${subcarrier.startFrequency/1000000}&nbsp;MHz</div><div>End Freq: ${subcarrier.endFrequency / 1000000} MHz</div><div>`;
+              endBottom[3] = 0;
+              endBottom[4] =`<div style="width:10em;"><div>Unused Subcarrier</div><div>Start Freq: ${subcarrier.startFrequency/1000000}&nbsp;MHz</div><div>End Freq: ${subcarrier.endFrequency / 1000000} MHz</div></div>`;
+              endTop[3] = 2.5;
+              endTop[4] =`<div style="width:10em;"><div>Unused Subcarrier</div><div>Start Freq: ${subcarrier.startFrequency/1000000}&nbsp;MHz</div><div>End Freq: ${subcarrier.endFrequency / 1000000} MHz</div></div>`;
+              unusedCount++;
+              break;
+            case 'excluded':
+              startBottom[5] = 0;
+              startBottom[6] =`<div style="width:10em;"><div>Excluded Subcarrier</div><div>Start Freq: ${subcarrier.startFrequency/1000000}&nbsp;MHz</div><div>End Freq: ${subcarrier.endFrequency / 1000000} MHz</div><div>`;
+              startTop[5] = 1.5;
+              startTop[6] =`<div style="width:10em;"><div>Excluded Subcarrier</div><div>Start Freq: ${subcarrier.startFrequency/1000000}&nbsp;MHz</div><div>End Freq: ${subcarrier.endFrequency / 1000000} MHz</div><div>`;
+              endBottom[5] = 0;
+              endBottom[6] =`<div style="width:10em;"><div>Excluded Subcarrier</div><div>Start Freq: ${subcarrier.startFrequency/1000000}&nbsp;MHz</div><div>End Freq: ${subcarrier.endFrequency / 1000000} MHz</div><div>`;
+              endTop[5] = 1.5;
+              endTop[6] =`<div style="width:10em;"><div>Excluded Subcarrier</div><div>Start Freq: ${subcarrier.startFrequency/1000000}&nbsp;MHz</div><div>End Freq: ${subcarrier.endFrequency / 1000000} MHz</div><div>`;
+              excludedCount++;
+              break;
+          }
+          graphObj.push(startBottom);
+          graphObj.push(startTop);
+          graphObj.push(endTop);
+          graphObj.push(endBottom);
+        }
+      };
+      
+
+      let clone;
+      clone = graphObj.slice(1, graphObj.length - 2);
+      if (unusedCount === 0) {
+        graphObj.push([-1000, null, ``, -10, ``, null, ``]);
+      }
+      if (excludedCount === 0) {
+        graphObj.push([-1000, null, ``, null, ``, -10, ``]);
+      }
+
+      graphObj.push([-1000, null, ``, null, ``, null, ``]);
+      clone.sort(compareNumbers);
+      let data = google.visualization.arrayToDataTable(graphObj, false);      
+      
+      let options = {
+        title: "Minislots and Excluded, Unused Subcarriers",
+        tooltip: {isHtml: true},
+        series: {
+          1: {color: "orange"},
+          2: {color: "purple"}
+        },
+        hAxis: {
+          title: "Frequency in MHz",
+          viewWindow: {
+            max: clone[clone.length - 1][0] + 1,
+            min: clone[1][0] - 1,
+          },
+          gridlineColor: '#fff',
+        },
+        explorer: {},
+        lineWidth: 1,
+        vAxis: {
+          viewWindow: {
+            min: -2,
+            max: 5
+          },
+          format: 'decimal',
+          gridlineColor: '#fff',
+
+          textPosition: "none"
+        }
+      };
+      var formatNumber = new google.visualization.NumberFormat({
+        fractionDigits: (subcarrierSpacing === 50000) ? 3 : 4
+      });
+      formatNumber.format(data, 0);
+      var chart = new google.visualization.AreaChart(document.getElementById('minislotVisualization'));
+      chart.draw(data, options);
+    }
+
+    function generateConfig() {
+
+      let config = ``;
+      /*
+interface ofdma 1:0/0.0 
+lower-freq 113000000 upper-freq 204000000
+pre-equalization
+no regular guardband
+multiple-iuc
+iuc-profile 4
+      */
+      //console.log(subcarriersArray, subcarrierSpacing);
+      let startSC = 148;
+      if ($('#subcarrierSpacing').val() == 50000) {
+        // 50 KHz spacing
+        startSC = 74;
+      }
+      let exclusionBandGroups = [];
+      for (let x = startSC; x < subcarriersArray.length; x++) {
+        if (subcarriersArray[x].endFrequency > parseInt($('#upperFreq').val())) {
+          break;
+        }
+        let sc = subcarriersArray[x];
+        if (sc.type === 'excluded' || sc.type === 'unused') {
+
+          if (exclusionBandGroups.length === 0) {
+            // no current group
+            exclusionBandGroups.push({ start: sc.startFrequency, end: sc.endFrequency });
+          } else if (exclusionBandGroups[exclusionBandGroups.length - 1].end === sc.startFrequency) {
+            // extend current group
+            exclusionBandGroups[exclusionBandGroups.length - 1].end = sc.endFrequency;
+          } else {
+            // new group
+            exclusionBandGroups.push({ start: sc.startFrequency, end: sc.endFrequency });
+          }
+        }
+      }
+      if (exclusionBandGroups.length > 0) {
+        config += `ofdma exclusion-band ${$('#ofdmaexclusionBandNumber').val()}\n`;
+        exclusionBandGroups.forEach((group, index) => {
+          config += `  exclusion-sc-group ${index + 1} ${group.start} ${group.end}\n`;
+        });
+        config += '\n';
+      }
+      let iucProfileCfg = ``;
+      iucProfileCfg += `ofdma iuc-profile ${$('#ofdmaIucProfileNumber').val()}\n`
+      iucProfileCfg += `  fine-ranging-iuc ${$('#minislotFineRanging').val()} 8000000\n`;
+      iucProfileCfg += `  initial-ranging-iuc ${$('#minislotInitialRanging').val()} 8000000\n`;
+      let possibleIUCs = [13, 12, 11, 10, 9, 6, 5];
+      let minislotCfg = ``;
+      possibleIUCs.reverse();
+      possibleIUCs.forEach((possibleIUC) => {
+        if (iucs[possibleIUC]) {
+          let iuc = iucs[possibleIUC];
+          let minislotGroups = [];
+          iucProfileCfg += `  data-iuc ${possibleIUC} modulation ${iuc.modulation} pilot-pattern ${iuc.pilotPattern}`;
+          iuc.forEach((minislot) => {
+            if (minislot.modulation !== iuc.modulation || minislot.pilotPattern != iuc.pilotPattern) {
+              if (minislotGroups.length === 0) {
+                // new group
+                minislotGroups.push({
+                  startFrequency: minislot.startFrequency,
+                  endFrequency: minislot.endFrequency,
+                  modulation: minislot.modulation,
+                  pilotPattern: minislot.pilotPattern
+                });
+              } else if (minislotGroups[minislotGroups.length - 1].endFrequency === minislot.startFrequency && minislotGroups[minislotGroups.length - 1].modulation === minislot.modulation && minislotGroups[minislotGroups.length - 1].pilotPattern == minislot.pilotPattern) {
+                minislotGroups[minislotGroups.length - 1].endFrequency = minislot.endFrequency;
+              } else {
+                minislotGroups.push({
+                  startFrequency: minislot.startFrequency,
+                  endFrequency: minislot.endFrequency,
+                  modulation: minislot.modulation,
+                  pilotPattern: minislot.pilotPattern
+                });
+              }
+            }
+          });
+          if (minislotGroups.length > 0) {
+            minislotCfg += `ofdma minislot-cfg ${$('#iucMinislotIndex' + possibleIUC).val()}\n`;
+            minislotGroups.forEach((minislotGroup, index) => {
+              minislotCfg += `  subcarrier-group-minislot ${index + 1} ${minislotGroup.startFrequency} ${minislotGroup.endFrequency} modulation ${minislotGroup.modulation} pilot-pattern ${minislotGroup.pilotPattern}\n`;
+            });
+            iucProfileCfg += ` minislot-cfg ${$('#iucMinislotIndex' + possibleIUC).val()}\n`;
+          } else {
+            iucProfileCfg += `\n`;
+          }
+
+        }
+      });
+      if (minislotCfg.length > 0) {
+        config += minislotCfg + '\n';
+      }
+      config += iucProfileCfg + '\n';
+      // OFDMA Channel
+      config += `interface ofdma ${$('#ofdmaInterfaceName').val()} \n`;
+      config += `  lower-freq ${($('#lowerActual').text().length > 0) ? $('#lowerActual').text().replace('Actual ', '') : $('#lowerFreq').val()} upper-freq ${($('#upperActual').text().length > 0) ? $('#upperActual').text().replace('Actual ', '') : $('#upperFreq').val()}\n`;
+      config += `  ${($('#regularGuardband').hasClass('active')) ? '' : 'no '}regular guardband\n`;
+      config += `  iuc-profile ${$('#ofdmaIucProfileNumber').val()}\n`;
+      if ($('#ofdmaPreEqualization').is(':checked')) {
+        config += `  pre-equalization${($('#ofdmaPreEqualizationAutoDecision').is(':checked')) ? ' auto-decision' : ''}\n`;
+      }
+      if (exclusionBandGroups.length > 0) {
+        config += `  exclusion-band ${$('#ofdmaexclusionBandNumber').val()}\n`;
+      }
+      config += `  sc-spacing ${$('#subcarrierSpacing').val().replace(/000/g, '')}\n`;
+      config += `  cyclic-prefix ${$('#cyclicPrefix').val()}\n`;
+      config += `  rolloff-period ${$('#rolloffPeriod').val()}\n`;
+      config += `  symbols-per-frame ${$('#symbolsPerFrame').val()}\n`;
+      config += `  power-level ${$('#ofdmaRxPower').val()}\n`;
+      config += `  no shutdown\n`;
+      $('#generatedConfig').text(config);
+      //console.log(exclusionBandGroups);
+    }
+
+    function compareNumbers(a, b) {
+      return a[0] - b[0];
+    }
+    let inputConfigObj;
+    function parseConfig() {
+      let config = $('#input').val();
+      console.log(config);
+      inputConfigObj = parser.parse(config);
+      console.log(inputConfigObj);
+      $('#activeInterfaces').empty();
+      let interfaceNames = Object.getOwnPropertyNames(inputConfigObj.ofdmaInterfaces);
+      interfaceNames.forEach((interfaceName) => {
+        if (inputConfigObj.ofdmaInterfaces[interfaceName].enabled) $('#activeInterfaces').append(new Option(interfaceName, interfaceName));
+      });
+
+      $('#activeInterfaces').prop('disabled', false);
+      $('#loadConfig').prop('disabled', false);
+      loadConfig();
+    }
+
+    function loadConfig() {
+      const ofdmaInterface = $('#activeInterfaces').val();
+      adjacentUpstreams = [];
+      console.log(ofdmaInterface);
+      if (inputConfigObj.ofdmaInterfaces[ofdmaInterface]) {
+        $('#ofdmaInterfaceName').val(ofdmaInterface);
+        const currentOfdmaInterface = inputConfigObj.ofdmaInterfaces[ofdmaInterface];
+        // subcarrier spacing
+        $('#subcarrierSpacing').val((currentOfdmaInterface.subcarrierSpacing) ? currentOfdmaInterface.subcarrierSpacing * 1000 : 50000).change();
+        // LowerFreq and UpperFreq
+        $('#lowerFreq').val(currentOfdmaInterface.lowerFreq).change();
+        $('#upperFreq').val(currentOfdmaInterface.upperFreq).change();
+        // load exclusion bands if any
+        if (currentOfdmaInterface.exclusionBand) {
+          console.log('found exclusion band')
+          const exclusionBand = inputConfigObj.exclusionBands[currentOfdmaInterface.exclusionBand];
+          if (exclusionBand) {
+            $('#ofdmaexclusionBandNumber').val(currentOfdmaInterface.exclusionBand);
+            excludedScs = [];
+            const groups = Object.getOwnPropertyNames(exclusionBand);
+            groups.forEach((groupName) => {
+              const group = exclusionBand[groupName];
+              $.each($("input[name='exclude']"), function () {
+                var data = $(this).parents('tr:eq(0)');
+                const index = parseInt($(data).find('td:eq(0)').text());
+                const startFreq = parseInt($(data).find('td:eq(1)').text());
+                const endFreq = parseInt($(data).find('td:eq(3)').text());
+                if (startFreq >= group.startFreq && endFreq <= group.endFreq) {
+                  // check the box
+                  $(this).prop('checked', true);
+                  $(this).checked = true;
+                  excludedScs.push(index);
+                }
+
+              });
+
+            });
+            // click the exclude button
+
+            updateSubcarriersAndMinislots();
+          }
+        }
+        // Load CP
+        if (currentOfdmaInterface.cyclicPrefix) cp1 = currentOfdmaInterface.cyclicPrefix;
+        // load RP
+        if (currentOfdmaInterface.rolloffPeriod) rp1 = currentOfdmaInterface.rolloffPeriod;
+
+        // load IUC Profiles
+        const iucProfile = inputConfigObj.iucProfiles[currentOfdmaInterface.iucProfile];
+        if (iucProfile) {
+          $('#ofdmaIucProfileNumber').val(currentOfdmaInterface.iucProfile);
+          const original = iucs[13].slice(0);
+          [5, 6, 9, 10, 11, 12, 13].forEach((iuc) => {
+            if (iucProfile[iuc]) iucs[iuc] = JSON.parse(JSON.stringify(original));
+          });
+          [13, 5, 6, 9, 10, 11, 12, 13].forEach((iuc) => {
+            if (iucProfile[iuc]) {
+              const currentIuc = iucProfile[iuc];
+              iucs[iuc] = applyModulationPilot(iucs[iuc], currentIuc.modulation, currentIuc.pilot, currentIuc.fineRanging, currentIuc.initialRanging);
+
+              // add minislot cfgs if present
+              if (currentIuc.minislot_cfg) {
+                const minislotCfg = inputConfigObj.minislotConfigs[currentIuc.minislot_cfg];
+                $('#iucMinislotIndex' + iuc).val(currentIuc.minislot_cfg);
+                for (const thisItem of minislotCfg) {
+                  const startFrequency = thisItem.startFrequency;
+                  const endFrequency = thisItem.endFrequency;
+                  const modulation = thisItem.modulation;
+                  const pilot = thisItem.pilot;
+                  for (const minislot of iucs[iuc]) {
+                    if (minislot.startFrequency >= startFrequency && minislot.endFrequency <= endFrequency) {
+                      minislot.modulation = modulation;
+                      minislot.pilotPattern = pilot;
+
+                    }
+                  }
+                }
+
+              }
+
+            }
+
+          });
+        }
+        // ATDMAs
+        const serviceGroups = Object.getOwnPropertyNames(inputConfigObj.serviceGroups);
+
+        if (serviceGroups.includes(currentOfdmaInterface.serviceGroup)) {
+          const serviceGroup = inputConfigObj.serviceGroups[currentOfdmaInterface.serviceGroup];
+
+          serviceGroup.atdmas.forEach((atdma) => {
+            adjacentUpstreams.push({
+              centerFrequency: atdma.freq,
+              startFrequency: atdma.freq - (atdma.width / 2),
+              endFrequency: atdma.freq + (atdma.width / 2),
+              channelWidth: atdma.width,
+              modulation: inputConfigObj.modulationProfiles[atdma.modProf],
+              rxPower: atdma.power / 10,
+              type: 'atdma',
+              name: atdma.id
+            });
+          });
+          minislotTable(13, parseInt($('#subcarrierSpacing').val()));
+          if (currentOfdmaInterface.guardBand === "alternate") {
+            $('#alternateGuardband').click();
+          }
+        }
+
+      }
+
+    }
+    function haveConfig() {
+      $('#parseInput').prop('disabled', this.value.length === 0);
+      if (this.value.length === 0) {
+        $('#activeInterfaces').empty();
+        $('#activeInterfaces').append(new Option("None", "None"));
+        $('#activeInterfaces').prop('disabled', this.value.length === 0)
+        $('#loadConfig').prop('disabled', this.value.length === 0)
+      }
+    }
+    google.charts.load('current', {
+      'packages': ['corechart']
+    });
+
+    $(document).ready(function () {
+      $('#subcarrierSpacing').change(() => {
+        updateSubcarriersAndMinislots();
+      });
+      $('#boundaryType').change(()=>{
+        let manualOrAuto = document.getElementById("boundaryType").value;
+        if (manualOrAuto == "manual") {
+          $('#lowerFreqHelp').text('Represents the start frequency of the first potential Data Subcarrier');
+          $('#upperFreqHelp').text('Represents the end frequency of the last potential Data Subcarrier');
+        } else {
+          $('#lowerFreqHelp').text('Represents the center frequency of the first potential Data Subcarrier');
+          $('#upperFreqHelp').text('Represents the center frequency of the last potential Data Subcarrier');
+        }
+        updateSubcarriersAndMinislots();
+      });
+      // lower Freq
+      $('#lowerFreq').change((evt) => {
+        let lowerFreq = parseInt($('#lowerFreq').val(), 10);
+        let subcarrierSpacing = parseInt($('#subcarrierSpacing').val(), 10);        
+        updateSubcarriersAndMinislots();
+      });
+      $('#btn8643').on('click', () => {
+        copyText = $('#code8643').val();
+        navigator.clipboard.writeText(copyText);
+        $('#btn8643').attr('data-original-title', "Copied to Clipboard").tooltip('show');
+      });
+      $('#btnOlder').on('click', () => {
+        copyText = $('#codeOlder').val();
+        navigator.clipboard.writeText(copyText);
+        $('#btnOlder').attr('data-original-title', "Copied to Clipboard").tooltip('show');
+      });
+      $('#lowerFreq').val('5000000');
+      let lowerFreq = parseInt($('#lowerFreq').val(), 10);
+      let subcarrierSpacing = parseInt($('#subcarrierSpacing').val(), 10);      
+      // upper freq
+      $('#upperFreq').change((evt) => {
+        let upperFreq = parseInt($('#upperFreq').val(), 10);
+        let subcarrierSpacing = parseInt($('#subcarrierSpacing').val(), 10);        
+        updateSubcarriersAndMinislots();
+      });
+      $('#upperFreq').val('25000000');
+      let upperFreq = parseInt($('#upperFreq').val(), 10);      
+      $('#ofdmaInterfaceName').on('change', generateConfig);
+      $('#ofdmaPreEqualization').on('change', generateConfig);
+      $('#ofdmaPreEqualizationAutoDecision').on('change', generateConfig);
+      $('#ofdmaIucProfileNumber').on('change', generateConfig);
+      $('#ofdmaexclusionBandNumber').on('change', generateConfig);
+      $('#iucMinislotIndex5').on('change', generateConfig);
+      $('#iucMinislotIndex6').on('change', generateConfig);
+      $('#iucMinislotIndex9').on('change', generateConfig);
+      $('#iucMinislotIndex10').on('change', generateConfig);
+      $('#iucMinislotIndex11').on('change', generateConfig);
+      $('#iucMinislotIndex12').on('change', generateConfig);
+      $('#iucMinislotIndex13').on('change', generateConfig);
+      $('#ofdmaRxPower').on('change', () => {
+        generateConfig();
+        psdVisualization();
+      })
+      $('#input').on('input selectionchange propertychange', haveConfig);
+      $('#parseInput').on('click', parseConfig);
+      $('#loadConfig').on('click', loadConfig);
+      google.charts.setOnLoadCallback(updateSubcarriersAndMinislots);
+      $('[data-toggle="tooltip"]').tooltip();
+    });
+  </script>
+  <script>
+    parser = /*
+ * Generated by PEG.js 0.10.0.
+ *
+ * http://pegjs.org/
+ */
+      (function () {
+        "use strict";
+
+        function peg$subclass(child, parent) {
+          function ctor() { this.constructor = child; }
+          ctor.prototype = parent.prototype;
+          child.prototype = new ctor();
+        }
+
+        function peg$SyntaxError(message, expected, found, location) {
+          this.message = message;
+          this.expected = expected;
+          this.found = found;
+          this.location = location;
+          this.name = "SyntaxError";
+
+          if (typeof Error.captureStackTrace === "function") {
+            Error.captureStackTrace(this, peg$SyntaxError);
+          }
+        }
+
+        peg$subclass(peg$SyntaxError, Error);
+
+        peg$SyntaxError.buildMessage = function (expected, found) {
+          var DESCRIBE_EXPECTATION_FNS = {
+            literal: function (expectation) {
+              return "\"" + literalEscape(expectation.text) + "\"";
+            },
+
+            "class": function (expectation) {
+              var escapedParts = "",
+                i;
+
+              for (i = 0; i < expectation.parts.length; i++) {
+                escapedParts += expectation.parts[i] instanceof Array
+                  ? classEscape(expectation.parts[i][0]) + "-" + classEscape(expectation.parts[i][1])
+                  : classEscape(expectation.parts[i]);
+              }
+
+              return "[" + (expectation.inverted ? "^" : "") + escapedParts + "]";
+            },
+
+            any: function (expectation) {
+              return "any character";
+            },
+
+            end: function (expectation) {
+              return "end of input";
+            },
+
+            other: function (expectation) {
+              return expectation.description;
+            }
+          };
+
+          function hex(ch) {
+            return ch.charCodeAt(0).toString(16).toUpperCase();
+          }
+
+          function literalEscape(s) {
+            return s
+              .replace(/\\/g, '\\\\')
+              .replace(/"/g, '\\"')
+              .replace(/\0/g, '\\0')
+              .replace(/\t/g, '\\t')
+              .replace(/\n/g, '\\n')
+              .replace(/\r/g, '\\r')
+              .replace(/[\x00-\x0F]/g, function (ch) { return '\\x0' + hex(ch); })
+              .replace(/[\x10-\x1F\x7F-\x9F]/g, function (ch) { return '\\x' + hex(ch); });
+          }
+
+          function classEscape(s) {
+            return s
+              .replace(/\\/g, '\\\\')
+              .replace(/\]/g, '\\]')
+              .replace(/\^/g, '\\^')
+              .replace(/-/g, '\\-')
+              .replace(/\0/g, '\\0')
+              .replace(/\t/g, '\\t')
+              .replace(/\n/g, '\\n')
+              .replace(/\r/g, '\\r')
+              .replace(/[\x00-\x0F]/g, function (ch) { return '\\x0' + hex(ch); })
+              .replace(/[\x10-\x1F\x7F-\x9F]/g, function (ch) { return '\\x' + hex(ch); });
+          }
+
+          function describeExpectation(expectation) {
+            return DESCRIBE_EXPECTATION_FNS[expectation.type](expectation);
+          }
+
+          function describeExpected(expected) {
+            var descriptions = new Array(expected.length),
+              i, j;
+
+            for (i = 0; i < expected.length; i++) {
+              descriptions[i] = describeExpectation(expected[i]);
+            }
+
+            descriptions.sort();
+
+            if (descriptions.length > 0) {
+              for (i = 1, j = 1; i < descriptions.length; i++) {
+                if (descriptions[i - 1] !== descriptions[i]) {
+                  descriptions[j] = descriptions[i];
+                  j++;
+                }
+              }
+              descriptions.length = j;
+            }
+
+            switch (descriptions.length) {
+              case 1:
+                return descriptions[0];
+
+              case 2:
+                return descriptions[0] + " or " + descriptions[1];
+
+              default:
+                return descriptions.slice(0, -1).join(", ")
+                  + ", or "
+                  + descriptions[descriptions.length - 1];
+            }
+          }
+
+          function describeFound(found) {
+            return found ? "\"" + literalEscape(found) + "\"" : "end of input";
+          }
+
+          return "Expected " + describeExpected(expected) + " but " + describeFound(found) + " found.";
+        };
+
+        function peg$parse(input, options) {
+          options = options !== void 0 ? options : {};
+
+          var peg$FAILED = {},
+
+            peg$startRuleFunctions = { start: peg$parsestart },
+            peg$startRuleFunction = peg$parsestart,
+
+            peg$c0 = peg$anyExpectation(),
+            peg$c1 = function () {
+              return {
+                minislotConfigs,
+                iucProfiles,
+                ofdmaInterfaces,
+                exclusionBands,
+                serviceGroups,
+                modulationProfiles
+              }
+            },
+            peg$c2 = "modulation-profile",
+            peg$c3 = peg$literalExpectation("modulation-profile", false),
+            peg$c4 = function (id, modulation) {
+              modulationProfiles[id] = modulation;
+            },
+            peg$c5 = "interface",
+            peg$c6 = peg$literalExpectation("interface", false),
+            peg$c7 = "docsis-mac",
+            peg$c8 = peg$literalExpectation("docsis-mac", false),
+            peg$c9 = function (docsisMac) {
+
+            },
+            peg$c10 = "-",
+            peg$c11 = peg$literalExpectation("-", false),
+            peg$c12 = function (id, docsisMac, channelId, status, type, freq, width, minislot, modProf, power, serviceGroup) {
+              console.log(id, type);
+              if (type === "ofdma" && serviceGroup) {
+                id = id.slice(0, -1);
+                ofdmaInterfaces[id].serviceGroup = serviceGroup
+              } else if (status == "UP" && serviceGroup) {
+                id = id.slice(0, -2);
+                // ATDMA
+                if (serviceGroups[serviceGroup] === undefined) serviceGroups[serviceGroup] = {};
+                if (serviceGroups[serviceGroup].atdmas === undefined) serviceGroups[serviceGroup].atdmas = [];
+                serviceGroups[serviceGroup].atdmas.push({
+                  id,
+                  freq,
+                  width,
+                  modProf,
+                  power
+                });
+              }
+            },
+            peg$c13 = "ofdma",
+            peg$c14 = peg$literalExpectation("ofdma", false),
+            peg$c15 = "exclusion-band",
+            peg$c16 = peg$literalExpectation("exclusion-band", false),
+            peg$c17 = function (id, subs) {
+              exclusionBands[id] = {};
+              const exclusionBand = exclusionBands[id];
+              subs.forEach((sub) => {
+                let props = Object.getOwnPropertyNames(sub);
+                props.forEach((prop) => {
+                  exclusionBand[prop] = sub[prop];
+                });
+              });
+            },
+            peg$c18 = "exclusion-sc-group",
+            peg$c19 = peg$literalExpectation("exclusion-sc-group", false),
+            peg$c20 = function (id, startFreq, endFreq) {
+              let t = {};
+              t[id] = {
+                id, startFreq, endFreq
+              };
+              return t;
+            },
+            peg$c21 = "minislot-cfg",
+            peg$c22 = peg$literalExpectation("minislot-cfg", false),
+            peg$c23 = function (id, subs) {
+              minislotConfigs[id] = [...subs.filter((item) => { return item !== undefined })];
+            },
+            peg$c24 = "subcarrier-group-minislot",
+            peg$c25 = peg$literalExpectation("subcarrier-group-minislot", false),
+            peg$c26 = "modulation",
+            peg$c27 = peg$literalExpectation("modulation", false),
+            peg$c28 = "pilot-pattern",
+            peg$c29 = peg$literalExpectation("pilot-pattern", false),
+            peg$c30 = function (id, start, end, modulation, pilot) {
+              return {
+                id,
+                startFrequency: start,
+                endFrequency: end,
+                modulation,
+                pilot
+              };
+            },
+            peg$c31 = function () { return undefined },
+            peg$c32 = "iuc-profile",
+            peg$c33 = peg$literalExpectation("iuc-profile", false),
+            peg$c34 = function (id, subs) {
+              iucProfiles[id] = {};
+              const iuc_profile = iucProfiles[id];
+              subs.forEach((sub) => {
+                let props = Object.getOwnPropertyNames(sub);
+                props.forEach((prop) => {
+                  iuc_profile[prop] = sub[prop];
+                });
+              });
+            },
+            peg$c35 = "fine-ranging-iuc",
+            peg$c36 = peg$literalExpectation("fine-ranging-iuc", false),
+            peg$c37 = function (fineSubCarriers, fineGuardBand) {
+              return {
+                fineSubCarriers,
+                fineGuardBand
+              }
+            },
+            peg$c38 = "initial-ranging-iuc",
+            peg$c39 = peg$literalExpectation("initial-ranging-iuc", false),
+            peg$c40 = function (initialSubCarriers, initialGuardBand) {
+              return {
+                initialSubCarriers,
+                initialGuardBand
+              }
+            },
+            peg$c41 = "data-iuc",
+            peg$c42 = peg$literalExpectation("data-iuc", false),
+            peg$c43 = function (id, modulation, pilot, minislot_cfg) {
+              let t = {};
+              t[id] = {
+                id,
+                modulation,
+                pilot,
+                minislot_cfg
+              };
+              return t;
+            },
+            peg$c44 = function (id, modulation, pilot) {
+              let t = {};
+              t[id] = {
+                id,
+                modulation,
+                pilot
+              };
+              return t;
+            },
+            peg$c45 = function () { return {}; },
+            peg$c46 = ":",
+            peg$c47 = peg$literalExpectation(":", false),
+            peg$c48 = "/",
+            peg$c49 = peg$literalExpectation("/", false),
+            peg$c50 = ".",
+            peg$c51 = peg$literalExpectation(".", false),
+            peg$c52 = function (id, subs) {
+              ofdmaInterfaces[id] = {};
+              const ofdma_interface = ofdmaInterfaces[id];
+              subs.forEach((sub) => {
+                let props = Object.getOwnPropertyNames(sub);
+                props.forEach((prop) => {
+                  ofdma_interface[prop] = sub[prop];
+                });
+              });
+            },
+            peg$c53 = "lower-freq",
+            peg$c54 = peg$literalExpectation("lower-freq", false),
+            peg$c55 = "upper-freq",
+            peg$c56 = peg$literalExpectation("upper-freq", false),
+            peg$c57 = function (lowerFreq, upperFreq) {
+              return {
+                lowerFreq,
+                upperFreq
+              };
+            },
+            peg$c58 = "power-level",
+            peg$c59 = peg$literalExpectation("power-level", false),
+            peg$c60 = function (powerLevel) {
+              return {
+                powerLevel
+              };
+            },
+            peg$c61 = "no",
+            peg$c62 = peg$literalExpectation("no", false),
+            peg$c63 = "regular",
+            peg$c64 = peg$literalExpectation("regular", false),
+            peg$c65 = "guardband",
+            peg$c66 = peg$literalExpectation("guardband", false),
+            peg$c67 = function (no) {
+              return {
+                guardBand: (no !== null) ? "alternate" : "regular"
+              };
+            },
+            peg$c68 = "pre-equalization",
+            peg$c69 = peg$literalExpectation("pre-equalization", false),
+            peg$c70 = "auto-decision",
+            peg$c71 = peg$literalExpectation("auto-decision", false),
+            peg$c72 = function (no, auto) {
+              return {
+                preEq: (no == null) ? false : true,
+                auto: (!no && auto) ? true : false
+              };
+            },
+            peg$c73 = function (exclusionBand) {
+              return {
+                exclusionBand
+              };
+            },
+            peg$c74 = function (iucProfile) {
+              return {
+                iucProfile
+              };
+            },
+            peg$c75 = "cyclic-prefix",
+            peg$c76 = peg$literalExpectation("cyclic-prefix", false),
+            peg$c77 = function (cyclicPrefix) {
+              return {
+                cyclicPrefix
+              }
+            },
+            peg$c78 = "rolloff-period",
+            peg$c79 = peg$literalExpectation("rolloff-period", false),
+            peg$c80 = function (rolloffPeriod) {
+              return {
+                rolloffPeriod
+              };
+            },
+            peg$c81 = "sc-spacing",
+            peg$c82 = peg$literalExpectation("sc-spacing", false),
+            peg$c83 = function (subcarrierSpacing) {
+              return {
+                subcarrierSpacing
+              };
+            },
+            peg$c84 = "shutdown",
+            peg$c85 = peg$literalExpectation("shutdown", false),
+            peg$c86 = function (no) {
+              return {
+                enabled: (no == null) ? false : true
+              };
+            },
+            peg$c87 = " ",
+            peg$c88 = peg$literalExpectation(" ", false),
+            peg$c89 = "\t",
+            peg$c90 = peg$literalExpectation("\t", false),
+            peg$c91 = "\r\n",
+            peg$c92 = peg$literalExpectation("\r\n", false),
+            peg$c93 = "\n",
+            peg$c94 = peg$literalExpectation("\n", false),
+            peg$c95 = "\r",
+            peg$c96 = peg$literalExpectation("\r", false),
+            peg$c97 = /^[0-9]/,
+            peg$c98 = peg$classExpectation([["0", "9"]], false, false),
+            peg$c99 = function (a) { return parseFloat(a); },
+            peg$c100 = function (a) { return parseInt(a); },
+            peg$c101 = /^[^ \t\r\n]/,
+            peg$c102 = peg$classExpectation([" ", "\t", "\r", "\n"], true, false),
+
+            peg$currPos = 0,
+            peg$savedPos = 0,
+            peg$posDetailsCache = [{ line: 1, column: 1 }],
+            peg$maxFailPos = 0,
+            peg$maxFailExpected = [],
+            peg$silentFails = 0,
+
+            peg$result;
+
+          if ("startRule" in options) {
+            if (!(options.startRule in peg$startRuleFunctions)) {
+              throw new Error("Can't start parsing from rule \"" + options.startRule + "\".");
+            }
+
+            peg$startRuleFunction = peg$startRuleFunctions[options.startRule];
+          }
+
+          function text() {
+            return input.substring(peg$savedPos, peg$currPos);
+          }
+
+          function location() {
+            return peg$computeLocation(peg$savedPos, peg$currPos);
+          }
+
+          function expected(description, location) {
+            location = location !== void 0 ? location : peg$computeLocation(peg$savedPos, peg$currPos)
+
+            throw peg$buildStructuredError(
+              [peg$otherExpectation(description)],
+              input.substring(peg$savedPos, peg$currPos),
+              location
+            );
+          }
+
+          function error(message, location) {
+            location = location !== void 0 ? location : peg$computeLocation(peg$savedPos, peg$currPos)
+
+            throw peg$buildSimpleError(message, location);
+          }
+
+          function peg$literalExpectation(text, ignoreCase) {
+            return { type: "literal", text: text, ignoreCase: ignoreCase };
+          }
+
+          function peg$classExpectation(parts, inverted, ignoreCase) {
+            return { type: "class", parts: parts, inverted: inverted, ignoreCase: ignoreCase };
+          }
+
+          function peg$anyExpectation() {
+            return { type: "any" };
+          }
+
+          function peg$endExpectation() {
+            return { type: "end" };
+          }
+
+          function peg$otherExpectation(description) {
+            return { type: "other", description: description };
+          }
+
+          function peg$computePosDetails(pos) {
+            var details = peg$posDetailsCache[pos], p;
+
+            if (details) {
+              return details;
+            } else {
+              p = pos - 1;
+              while (!peg$posDetailsCache[p]) {
+                p--;
+              }
+
+              details = peg$posDetailsCache[p];
+              details = {
+                line: details.line,
+                column: details.column
+              };
+
+              while (p < pos) {
+                if (input.charCodeAt(p) === 10) {
+                  details.line++;
+                  details.column = 1;
+                } else {
+                  details.column++;
+                }
+
+                p++;
+              }
+
+              peg$posDetailsCache[pos] = details;
+              return details;
+            }
+          }
+
+          function peg$computeLocation(startPos, endPos) {
+            var startPosDetails = peg$computePosDetails(startPos),
+              endPosDetails = peg$computePosDetails(endPos);
+
+            return {
+              start: {
+                offset: startPos,
+                line: startPosDetails.line,
+                column: startPosDetails.column
+              },
+              end: {
+                offset: endPos,
+                line: endPosDetails.line,
+                column: endPosDetails.column
+              }
+            };
+          }
+
+          function peg$fail(expected) {
+            if (peg$currPos < peg$maxFailPos) { return; }
+
+            if (peg$currPos > peg$maxFailPos) {
+              peg$maxFailPos = peg$currPos;
+              peg$maxFailExpected = [];
+            }
+
+            peg$maxFailExpected.push(expected);
+          }
+
+          function peg$buildSimpleError(message, location) {
+            return new peg$SyntaxError(message, null, null, location);
+          }
+
+          function peg$buildStructuredError(expected, found, location) {
+            return new peg$SyntaxError(
+              peg$SyntaxError.buildMessage(expected, found),
+              expected,
+              found,
+              location
+            );
+          }
+
+          function peg$parsestart() {
+            var s0, s1, s2, s3, s4, s5;
+
+            s0 = peg$currPos;
+            s1 = [];
+            s2 = peg$parseignorableLine();
+            while (s2 !== peg$FAILED) {
+              s1.push(s2);
+              s2 = peg$parseignorableLine();
+            }
+            if (s1 !== peg$FAILED) {
+              s2 = [];
+              s3 = peg$parserelevant();
+              if (s3 !== peg$FAILED) {
+                while (s3 !== peg$FAILED) {
+                  s2.push(s3);
+                  s3 = peg$parserelevant();
+                }
+              } else {
+                s2 = peg$FAILED;
+              }
+              if (s2 !== peg$FAILED) {
+                s3 = [];
+                s4 = peg$parseignorableLine();
+                while (s4 !== peg$FAILED) {
+                  s3.push(s4);
+                  s4 = peg$parseignorableLine();
+                }
+                if (s3 !== peg$FAILED) {
+                  s4 = [];
+                  if (input.length > peg$currPos) {
+                    s5 = input.charAt(peg$currPos);
+                    peg$currPos++;
+                  } else {
+                    s5 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c0); }
+                  }
+                  while (s5 !== peg$FAILED) {
+                    s4.push(s5);
+                    if (input.length > peg$currPos) {
+                      s5 = input.charAt(peg$currPos);
+                      peg$currPos++;
+                    } else {
+                      s5 = peg$FAILED;
+                      if (peg$silentFails === 0) { peg$fail(peg$c0); }
+                    }
+                  }
+                  if (s4 !== peg$FAILED) {
+                    peg$savedPos = s0;
+                    s1 = peg$c1();
+                    s0 = s1;
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+
+            return s0;
+          }
+
+          function peg$parserelevant() {
+            var s0;
+
+            s0 = peg$parseminislot_cfg();
+            if (s0 === peg$FAILED) {
+              s0 = peg$parseiuc_profile();
+              if (s0 === peg$FAILED) {
+                s0 = peg$parseinterface_ofdma();
+                if (s0 === peg$FAILED) {
+                  s0 = peg$parseexclusionBand();
+                  if (s0 === peg$FAILED) {
+                    s0 = peg$parsedocsisMac();
+                    if (s0 === peg$FAILED) {
+                      s0 = peg$parsemodulationProfile();
+                      if (s0 === peg$FAILED) {
+                        if (input.length > peg$currPos) {
+                          s0 = input.charAt(peg$currPos);
+                          peg$currPos++;
+                        } else {
+                          s0 = peg$FAILED;
+                          if (peg$silentFails === 0) { peg$fail(peg$c0); }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+
+            return s0;
+          }
+
+          function peg$parsemodulationProfile() {
+            var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14;
+
+            s0 = peg$currPos;
+            s1 = peg$parseS();
+            if (s1 !== peg$FAILED) {
+              if (input.substr(peg$currPos, 18) === peg$c2) {
+                s2 = peg$c2;
+                peg$currPos += 18;
+              } else {
+                s2 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c3); }
+              }
+              if (s2 !== peg$FAILED) {
+                s3 = peg$parseS();
+                if (s3 !== peg$FAILED) {
+                  s4 = peg$parsenumber();
+                  if (s4 !== peg$FAILED) {
+                    s5 = peg$parserestOfLine();
+                    if (s5 !== peg$FAILED) {
+                      s6 = peg$parseNL();
+                      if (s6 !== peg$FAILED) {
+                        s7 = peg$parseS();
+                        if (s7 !== peg$FAILED) {
+                          s8 = peg$parsestring();
+                          if (s8 !== peg$FAILED) {
+                            s9 = peg$parseS();
+                            if (s9 !== peg$FAILED) {
+                              s10 = peg$parsestring();
+                              if (s10 !== peg$FAILED) {
+                                s11 = peg$parseS();
+                                if (s11 !== peg$FAILED) {
+                                  s12 = peg$parsestring();
+                                  if (s12 !== peg$FAILED) {
+                                    s13 = peg$parserestOfLine();
+                                    if (s13 !== peg$FAILED) {
+                                      s14 = peg$parseNL();
+                                      if (s14 !== peg$FAILED) {
+                                        peg$savedPos = s0;
+                                        s1 = peg$c4(s4, s12);
+                                        s0 = s1;
+                                      } else {
+                                        peg$currPos = s0;
+                                        s0 = peg$FAILED;
+                                      }
+                                    } else {
+                                      peg$currPos = s0;
+                                      s0 = peg$FAILED;
+                                    }
+                                  } else {
+                                    peg$currPos = s0;
+                                    s0 = peg$FAILED;
+                                  }
+                                } else {
+                                  peg$currPos = s0;
+                                  s0 = peg$FAILED;
+                                }
+                              } else {
+                                peg$currPos = s0;
+                                s0 = peg$FAILED;
+                              }
+                            } else {
+                              peg$currPos = s0;
+                              s0 = peg$FAILED;
+                            }
+                          } else {
+                            peg$currPos = s0;
+                            s0 = peg$FAILED;
+                          }
+                        } else {
+                          peg$currPos = s0;
+                          s0 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+
+            return s0;
+          }
+
+          function peg$parsedocsisMac() {
+            var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
+
+            s0 = peg$currPos;
+            if (input.substr(peg$currPos, 9) === peg$c5) {
+              s1 = peg$c5;
+              peg$currPos += 9;
+            } else {
+              s1 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c6); }
+            }
+            if (s1 !== peg$FAILED) {
+              s2 = peg$parseS();
+              if (s2 !== peg$FAILED) {
+                if (input.substr(peg$currPos, 10) === peg$c7) {
+                  s3 = peg$c7;
+                  peg$currPos += 10;
+                } else {
+                  s3 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c8); }
+                }
+                if (s3 !== peg$FAILED) {
+                  s4 = peg$parseS();
+                  if (s4 !== peg$FAILED) {
+                    s5 = peg$parsenumber();
+                    if (s5 !== peg$FAILED) {
+                      s6 = peg$parserestOfLine();
+                      if (s6 !== peg$FAILED) {
+                        s7 = peg$parseNL();
+                        if (s7 !== peg$FAILED) {
+                          s8 = [];
+                          s9 = peg$parsedocsisMacSubs();
+                          while (s9 !== peg$FAILED) {
+                            s8.push(s9);
+                            s9 = peg$parsedocsisMacSubs();
+                          }
+                          if (s8 !== peg$FAILED) {
+                            peg$savedPos = s0;
+                            s1 = peg$c9(s5);
+                            s0 = s1;
+                          } else {
+                            peg$currPos = s0;
+                            s0 = peg$FAILED;
+                          }
+                        } else {
+                          peg$currPos = s0;
+                          s0 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+
+            return s0;
+          }
+
+          function peg$parsedocsisMacSubs() {
+            var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23;
+
+            s0 = peg$currPos;
+            s1 = peg$parsestring();
+            if (s1 !== peg$FAILED) {
+              s2 = peg$parseS();
+              if (s2 !== peg$FAILED) {
+                s3 = peg$parsenumber();
+                if (s3 !== peg$FAILED) {
+                  s4 = peg$parseS();
+                  if (s4 !== peg$FAILED) {
+                    s5 = peg$parsenumber();
+                    if (s5 !== peg$FAILED) {
+                      s6 = peg$parseS();
+                      if (s6 !== peg$FAILED) {
+                        s7 = peg$parsestring();
+                        if (s7 !== peg$FAILED) {
+                          s8 = peg$parseS();
+                          if (s8 !== peg$FAILED) {
+                            s9 = peg$parsestring();
+                            if (s9 !== peg$FAILED) {
+                              s10 = peg$parseS();
+                              if (s10 !== peg$FAILED) {
+                                s11 = peg$parsenumber();
+                                if (s11 !== peg$FAILED) {
+                                  s12 = peg$parseS();
+                                  if (s12 !== peg$FAILED) {
+                                    s13 = peg$parsenumber();
+                                    if (s13 !== peg$FAILED) {
+                                      s14 = peg$parseS();
+                                      if (s14 !== peg$FAILED) {
+                                        if (input.charCodeAt(peg$currPos) === 45) {
+                                          s15 = peg$c10;
+                                          peg$currPos++;
+                                        } else {
+                                          s15 = peg$FAILED;
+                                          if (peg$silentFails === 0) { peg$fail(peg$c11); }
+                                        }
+                                        if (s15 === peg$FAILED) {
+                                          s15 = peg$parsenumber();
+                                        }
+                                        if (s15 !== peg$FAILED) {
+                                          s16 = peg$parseS();
+                                          if (s16 !== peg$FAILED) {
+                                            s17 = peg$parsenumber();
+                                            if (s17 !== peg$FAILED) {
+                                              s18 = peg$parseS();
+                                              if (s18 !== peg$FAILED) {
+                                                s19 = peg$parsenumber();
+                                                if (s19 !== peg$FAILED) {
+                                                  s20 = peg$parseS();
+                                                  if (s20 !== peg$FAILED) {
+                                                    s21 = peg$parsestring();
+                                                    if (s21 === peg$FAILED) {
+                                                      s21 = null;
+                                                    }
+                                                    if (s21 !== peg$FAILED) {
+                                                      s22 = peg$parserestOfLine();
+                                                      if (s22 !== peg$FAILED) {
+                                                        s23 = peg$parseNL();
+                                                        if (s23 !== peg$FAILED) {
+                                                          peg$savedPos = s0;
+                                                          s1 = peg$c12(s1, s3, s5, s7, s9, s11, s13, s15, s17, s19, s21);
+                                                          s0 = s1;
+                                                        } else {
+                                                          peg$currPos = s0;
+                                                          s0 = peg$FAILED;
+                                                        }
+                                                      } else {
+                                                        peg$currPos = s0;
+                                                        s0 = peg$FAILED;
+                                                      }
+                                                    } else {
+                                                      peg$currPos = s0;
+                                                      s0 = peg$FAILED;
+                                                    }
+                                                  } else {
+                                                    peg$currPos = s0;
+                                                    s0 = peg$FAILED;
+                                                  }
+                                                } else {
+                                                  peg$currPos = s0;
+                                                  s0 = peg$FAILED;
+                                                }
+                                              } else {
+                                                peg$currPos = s0;
+                                                s0 = peg$FAILED;
+                                              }
+                                            } else {
+                                              peg$currPos = s0;
+                                              s0 = peg$FAILED;
+                                            }
+                                          } else {
+                                            peg$currPos = s0;
+                                            s0 = peg$FAILED;
+                                          }
+                                        } else {
+                                          peg$currPos = s0;
+                                          s0 = peg$FAILED;
+                                        }
+                                      } else {
+                                        peg$currPos = s0;
+                                        s0 = peg$FAILED;
+                                      }
+                                    } else {
+                                      peg$currPos = s0;
+                                      s0 = peg$FAILED;
+                                    }
+                                  } else {
+                                    peg$currPos = s0;
+                                    s0 = peg$FAILED;
+                                  }
+                                } else {
+                                  peg$currPos = s0;
+                                  s0 = peg$FAILED;
+                                }
+                              } else {
+                                peg$currPos = s0;
+                                s0 = peg$FAILED;
+                              }
+                            } else {
+                              peg$currPos = s0;
+                              s0 = peg$FAILED;
+                            }
+                          } else {
+                            peg$currPos = s0;
+                            s0 = peg$FAILED;
+                          }
+                        } else {
+                          peg$currPos = s0;
+                          s0 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+
+            return s0;
+          }
+
+          function peg$parseexclusionBand() {
+            var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10;
+
+            s0 = peg$currPos;
+            s1 = peg$parseS();
+            if (s1 !== peg$FAILED) {
+              if (input.substr(peg$currPos, 5) === peg$c13) {
+                s2 = peg$c13;
+                peg$currPos += 5;
+              } else {
+                s2 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c14); }
+              }
+              if (s2 !== peg$FAILED) {
+                s3 = peg$parseS();
+                if (s3 !== peg$FAILED) {
+                  if (input.substr(peg$currPos, 14) === peg$c15) {
+                    s4 = peg$c15;
+                    peg$currPos += 14;
+                  } else {
+                    s4 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c16); }
+                  }
+                  if (s4 !== peg$FAILED) {
+                    s5 = peg$parseS();
+                    if (s5 !== peg$FAILED) {
+                      s6 = peg$parsenumber();
+                      if (s6 !== peg$FAILED) {
+                        s7 = peg$parserestOfLine();
+                        if (s7 !== peg$FAILED) {
+                          s8 = peg$parseNL();
+                          if (s8 !== peg$FAILED) {
+                            s9 = [];
+                            s10 = peg$parseexclusionBandSubs();
+                            while (s10 !== peg$FAILED) {
+                              s9.push(s10);
+                              s10 = peg$parseexclusionBandSubs();
+                            }
+                            if (s9 !== peg$FAILED) {
+                              peg$savedPos = s0;
+                              s1 = peg$c17(s6, s9);
+                              s0 = s1;
+                            } else {
+                              peg$currPos = s0;
+                              s0 = peg$FAILED;
+                            }
+                          } else {
+                            peg$currPos = s0;
+                            s0 = peg$FAILED;
+                          }
+                        } else {
+                          peg$currPos = s0;
+                          s0 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+
+            return s0;
+          }
+
+          function peg$parseexclusionBandSubs() {
+            var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10;
+
+            s0 = peg$currPos;
+            s1 = peg$parseS();
+            if (s1 !== peg$FAILED) {
+              if (input.substr(peg$currPos, 18) === peg$c18) {
+                s2 = peg$c18;
+                peg$currPos += 18;
+              } else {
+                s2 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c19); }
+              }
+              if (s2 !== peg$FAILED) {
+                s3 = peg$parseS();
+                if (s3 !== peg$FAILED) {
+                  s4 = peg$parsenumber();
+                  if (s4 !== peg$FAILED) {
+                    s5 = peg$parseS();
+                    if (s5 !== peg$FAILED) {
+                      s6 = peg$parsenumber();
+                      if (s6 !== peg$FAILED) {
+                        s7 = peg$parseS();
+                        if (s7 !== peg$FAILED) {
+                          s8 = peg$parsenumber();
+                          if (s8 !== peg$FAILED) {
+                            s9 = peg$parserestOfLine();
+                            if (s9 !== peg$FAILED) {
+                              s10 = peg$parseNL();
+                              if (s10 !== peg$FAILED) {
+                                peg$savedPos = s0;
+                                s1 = peg$c20(s4, s6, s8);
+                                s0 = s1;
+                              } else {
+                                peg$currPos = s0;
+                                s0 = peg$FAILED;
+                              }
+                            } else {
+                              peg$currPos = s0;
+                              s0 = peg$FAILED;
+                            }
+                          } else {
+                            peg$currPos = s0;
+                            s0 = peg$FAILED;
+                          }
+                        } else {
+                          peg$currPos = s0;
+                          s0 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+
+            return s0;
+          }
+
+          function peg$parseminislot_cfg() {
+            var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10;
+
+            s0 = peg$currPos;
+            s1 = peg$parseS();
+            if (s1 !== peg$FAILED) {
+              if (input.substr(peg$currPos, 5) === peg$c13) {
+                s2 = peg$c13;
+                peg$currPos += 5;
+              } else {
+                s2 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c14); }
+              }
+              if (s2 !== peg$FAILED) {
+                s3 = peg$parseS();
+                if (s3 !== peg$FAILED) {
+                  if (input.substr(peg$currPos, 12) === peg$c21) {
+                    s4 = peg$c21;
+                    peg$currPos += 12;
+                  } else {
+                    s4 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c22); }
+                  }
+                  if (s4 !== peg$FAILED) {
+                    s5 = peg$parseS();
+                    if (s5 !== peg$FAILED) {
+                      s6 = peg$parsenumber();
+                      if (s6 !== peg$FAILED) {
+                        s7 = peg$parserestOfLine();
+                        if (s7 !== peg$FAILED) {
+                          s8 = peg$parseNL();
+                          if (s8 !== peg$FAILED) {
+                            s9 = [];
+                            s10 = peg$parseminislot_cfg_sub();
+                            if (s10 !== peg$FAILED) {
+                              while (s10 !== peg$FAILED) {
+                                s9.push(s10);
+                                s10 = peg$parseminislot_cfg_sub();
+                              }
+                            } else {
+                              s9 = peg$FAILED;
+                            }
+                            if (s9 !== peg$FAILED) {
+                              peg$savedPos = s0;
+                              s1 = peg$c23(s6, s9);
+                              s0 = s1;
+                            } else {
+                              peg$currPos = s0;
+                              s0 = peg$FAILED;
+                            }
+                          } else {
+                            peg$currPos = s0;
+                            s0 = peg$FAILED;
+                          }
+                        } else {
+                          peg$currPos = s0;
+                          s0 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+
+            return s0;
+          }
+
+          function peg$parseminislot_cfg_sub() {
+            var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18;
+
+            s0 = peg$currPos;
+            s1 = peg$parseS();
+            if (s1 !== peg$FAILED) {
+              if (input.substr(peg$currPos, 25) === peg$c24) {
+                s2 = peg$c24;
+                peg$currPos += 25;
+              } else {
+                s2 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c25); }
+              }
+              if (s2 !== peg$FAILED) {
+                s3 = peg$parseS();
+                if (s3 !== peg$FAILED) {
+                  s4 = peg$parsenumber();
+                  if (s4 !== peg$FAILED) {
+                    s5 = peg$parseS();
+                    if (s5 !== peg$FAILED) {
+                      s6 = peg$parsenumber();
+                      if (s6 !== peg$FAILED) {
+                        s7 = peg$parseS();
+                        if (s7 !== peg$FAILED) {
+                          s8 = peg$parsenumber();
+                          if (s8 !== peg$FAILED) {
+                            s9 = peg$parseS();
+                            if (s9 !== peg$FAILED) {
+                              if (input.substr(peg$currPos, 10) === peg$c26) {
+                                s10 = peg$c26;
+                                peg$currPos += 10;
+                              } else {
+                                s10 = peg$FAILED;
+                                if (peg$silentFails === 0) { peg$fail(peg$c27); }
+                              }
+                              if (s10 !== peg$FAILED) {
+                                s11 = peg$parseS();
+                                if (s11 !== peg$FAILED) {
+                                  s12 = peg$parsestring();
+                                  if (s12 !== peg$FAILED) {
+                                    s13 = peg$parseS();
+                                    if (s13 !== peg$FAILED) {
+                                      if (input.substr(peg$currPos, 13) === peg$c28) {
+                                        s14 = peg$c28;
+                                        peg$currPos += 13;
+                                      } else {
+                                        s14 = peg$FAILED;
+                                        if (peg$silentFails === 0) { peg$fail(peg$c29); }
+                                      }
+                                      if (s14 !== peg$FAILED) {
+                                        s15 = peg$parseS();
+                                        if (s15 !== peg$FAILED) {
+                                          s16 = peg$parsenumber();
+                                          if (s16 !== peg$FAILED) {
+                                            s17 = peg$parserestOfLine();
+                                            if (s17 !== peg$FAILED) {
+                                              s18 = peg$parseNL();
+                                              if (s18 !== peg$FAILED) {
+                                                peg$savedPos = s0;
+                                                s1 = peg$c30(s4, s6, s8, s12, s16);
+                                                s0 = s1;
+                                              } else {
+                                                peg$currPos = s0;
+                                                s0 = peg$FAILED;
+                                              }
+                                            } else {
+                                              peg$currPos = s0;
+                                              s0 = peg$FAILED;
+                                            }
+                                          } else {
+                                            peg$currPos = s0;
+                                            s0 = peg$FAILED;
+                                          }
+                                        } else {
+                                          peg$currPos = s0;
+                                          s0 = peg$FAILED;
+                                        }
+                                      } else {
+                                        peg$currPos = s0;
+                                        s0 = peg$FAILED;
+                                      }
+                                    } else {
+                                      peg$currPos = s0;
+                                      s0 = peg$FAILED;
+                                    }
+                                  } else {
+                                    peg$currPos = s0;
+                                    s0 = peg$FAILED;
+                                  }
+                                } else {
+                                  peg$currPos = s0;
+                                  s0 = peg$FAILED;
+                                }
+                              } else {
+                                peg$currPos = s0;
+                                s0 = peg$FAILED;
+                              }
+                            } else {
+                              peg$currPos = s0;
+                              s0 = peg$FAILED;
+                            }
+                          } else {
+                            peg$currPos = s0;
+                            s0 = peg$FAILED;
+                          }
+                        } else {
+                          peg$currPos = s0;
+                          s0 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+            if (s0 === peg$FAILED) {
+              s0 = peg$currPos;
+              s1 = peg$parseignorableLine();
+              if (s1 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c31();
+              }
+              s0 = s1;
+            }
+
+            return s0;
+          }
+
+          function peg$parseiuc_profile() {
+            var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
+
+            s0 = peg$currPos;
+            if (input.substr(peg$currPos, 5) === peg$c13) {
+              s1 = peg$c13;
+              peg$currPos += 5;
+            } else {
+              s1 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c14); }
+            }
+            if (s1 !== peg$FAILED) {
+              s2 = peg$parseS();
+              if (s2 !== peg$FAILED) {
+                if (input.substr(peg$currPos, 11) === peg$c32) {
+                  s3 = peg$c32;
+                  peg$currPos += 11;
+                } else {
+                  s3 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c33); }
+                }
+                if (s3 !== peg$FAILED) {
+                  s4 = peg$parseS();
+                  if (s4 !== peg$FAILED) {
+                    s5 = peg$parsenumber();
+                    if (s5 !== peg$FAILED) {
+                      s6 = peg$parserestOfLine();
+                      if (s6 !== peg$FAILED) {
+                        s7 = peg$parseNL();
+                        if (s7 !== peg$FAILED) {
+                          s8 = [];
+                          s9 = peg$parseiuc_profile_subs();
+                          if (s9 !== peg$FAILED) {
+                            while (s9 !== peg$FAILED) {
+                              s8.push(s9);
+                              s9 = peg$parseiuc_profile_subs();
+                            }
+                          } else {
+                            s8 = peg$FAILED;
+                          }
+                          if (s8 !== peg$FAILED) {
+                            peg$savedPos = s0;
+                            s1 = peg$c34(s5, s8);
+                            s0 = s1;
+                          } else {
+                            peg$currPos = s0;
+                            s0 = peg$FAILED;
+                          }
+                        } else {
+                          peg$currPos = s0;
+                          s0 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+
+            return s0;
+          }
+
+          function peg$parseiuc_profile_subs() {
+            var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18;
+
+            s0 = peg$currPos;
+            s1 = peg$parseS();
+            if (s1 !== peg$FAILED) {
+              if (input.substr(peg$currPos, 16) === peg$c35) {
+                s2 = peg$c35;
+                peg$currPos += 16;
+              } else {
+                s2 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c36); }
+              }
+              if (s2 !== peg$FAILED) {
+                s3 = peg$parseS();
+                if (s3 !== peg$FAILED) {
+                  s4 = peg$parsenumber();
+                  if (s4 !== peg$FAILED) {
+                    s5 = peg$parseS();
+                    if (s5 !== peg$FAILED) {
+                      s6 = peg$parsenumber();
+                      if (s6 !== peg$FAILED) {
+                        s7 = peg$parserestOfLine();
+                        if (s7 !== peg$FAILED) {
+                          s8 = peg$parseNL();
+                          if (s8 !== peg$FAILED) {
+                            peg$savedPos = s0;
+                            s1 = peg$c37(s4, s6);
+                            s0 = s1;
+                          } else {
+                            peg$currPos = s0;
+                            s0 = peg$FAILED;
+                          }
+                        } else {
+                          peg$currPos = s0;
+                          s0 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+            if (s0 === peg$FAILED) {
+              s0 = peg$currPos;
+              s1 = peg$parseS();
+              if (s1 !== peg$FAILED) {
+                if (input.substr(peg$currPos, 19) === peg$c38) {
+                  s2 = peg$c38;
+                  peg$currPos += 19;
+                } else {
+                  s2 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c39); }
+                }
+                if (s2 !== peg$FAILED) {
+                  s3 = peg$parseS();
+                  if (s3 !== peg$FAILED) {
+                    s4 = peg$parsenumber();
+                    if (s4 !== peg$FAILED) {
+                      s5 = peg$parseS();
+                      if (s5 !== peg$FAILED) {
+                        s6 = peg$parsenumber();
+                        if (s6 !== peg$FAILED) {
+                          s7 = peg$parserestOfLine();
+                          if (s7 !== peg$FAILED) {
+                            s8 = peg$parseNL();
+                            if (s8 !== peg$FAILED) {
+                              peg$savedPos = s0;
+                              s1 = peg$c40(s4, s6);
+                              s0 = s1;
+                            } else {
+                              peg$currPos = s0;
+                              s0 = peg$FAILED;
+                            }
+                          } else {
+                            peg$currPos = s0;
+                            s0 = peg$FAILED;
+                          }
+                        } else {
+                          peg$currPos = s0;
+                          s0 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+              if (s0 === peg$FAILED) {
+                s0 = peg$currPos;
+                s1 = peg$parseS();
+                if (s1 !== peg$FAILED) {
+                  if (input.substr(peg$currPos, 8) === peg$c41) {
+                    s2 = peg$c41;
+                    peg$currPos += 8;
+                  } else {
+                    s2 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c42); }
+                  }
+                  if (s2 !== peg$FAILED) {
+                    s3 = peg$parseS();
+                    if (s3 !== peg$FAILED) {
+                      s4 = peg$parsenumber();
+                      if (s4 !== peg$FAILED) {
+                        s5 = peg$parseS();
+                        if (s5 !== peg$FAILED) {
+                          if (input.substr(peg$currPos, 10) === peg$c26) {
+                            s6 = peg$c26;
+                            peg$currPos += 10;
+                          } else {
+                            s6 = peg$FAILED;
+                            if (peg$silentFails === 0) { peg$fail(peg$c27); }
+                          }
+                          if (s6 !== peg$FAILED) {
+                            s7 = peg$parseS();
+                            if (s7 !== peg$FAILED) {
+                              s8 = peg$parsestring();
+                              if (s8 !== peg$FAILED) {
+                                s9 = peg$parseS();
+                                if (s9 !== peg$FAILED) {
+                                  if (input.substr(peg$currPos, 13) === peg$c28) {
+                                    s10 = peg$c28;
+                                    peg$currPos += 13;
+                                  } else {
+                                    s10 = peg$FAILED;
+                                    if (peg$silentFails === 0) { peg$fail(peg$c29); }
+                                  }
+                                  if (s10 !== peg$FAILED) {
+                                    s11 = peg$parseS();
+                                    if (s11 !== peg$FAILED) {
+                                      s12 = peg$parsenumber();
+                                      if (s12 !== peg$FAILED) {
+                                        s13 = peg$parseS();
+                                        if (s13 !== peg$FAILED) {
+                                          if (input.substr(peg$currPos, 12) === peg$c21) {
+                                            s14 = peg$c21;
+                                            peg$currPos += 12;
+                                          } else {
+                                            s14 = peg$FAILED;
+                                            if (peg$silentFails === 0) { peg$fail(peg$c22); }
+                                          }
+                                          if (s14 !== peg$FAILED) {
+                                            s15 = peg$parseS();
+                                            if (s15 !== peg$FAILED) {
+                                              s16 = peg$parsenumber();
+                                              if (s16 !== peg$FAILED) {
+                                                s17 = peg$parserestOfLine();
+                                                if (s17 !== peg$FAILED) {
+                                                  s18 = peg$parseNL();
+                                                  if (s18 !== peg$FAILED) {
+                                                    peg$savedPos = s0;
+                                                    s1 = peg$c43(s4, s8, s12, s16);
+                                                    s0 = s1;
+                                                  } else {
+                                                    peg$currPos = s0;
+                                                    s0 = peg$FAILED;
+                                                  }
+                                                } else {
+                                                  peg$currPos = s0;
+                                                  s0 = peg$FAILED;
+                                                }
+                                              } else {
+                                                peg$currPos = s0;
+                                                s0 = peg$FAILED;
+                                              }
+                                            } else {
+                                              peg$currPos = s0;
+                                              s0 = peg$FAILED;
+                                            }
+                                          } else {
+                                            peg$currPos = s0;
+                                            s0 = peg$FAILED;
+                                          }
+                                        } else {
+                                          peg$currPos = s0;
+                                          s0 = peg$FAILED;
+                                        }
+                                      } else {
+                                        peg$currPos = s0;
+                                        s0 = peg$FAILED;
+                                      }
+                                    } else {
+                                      peg$currPos = s0;
+                                      s0 = peg$FAILED;
+                                    }
+                                  } else {
+                                    peg$currPos = s0;
+                                    s0 = peg$FAILED;
+                                  }
+                                } else {
+                                  peg$currPos = s0;
+                                  s0 = peg$FAILED;
+                                }
+                              } else {
+                                peg$currPos = s0;
+                                s0 = peg$FAILED;
+                              }
+                            } else {
+                              peg$currPos = s0;
+                              s0 = peg$FAILED;
+                            }
+                          } else {
+                            peg$currPos = s0;
+                            s0 = peg$FAILED;
+                          }
+                        } else {
+                          peg$currPos = s0;
+                          s0 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+                if (s0 === peg$FAILED) {
+                  s0 = peg$currPos;
+                  s1 = peg$parseS();
+                  if (s1 !== peg$FAILED) {
+                    if (input.substr(peg$currPos, 8) === peg$c41) {
+                      s2 = peg$c41;
+                      peg$currPos += 8;
+                    } else {
+                      s2 = peg$FAILED;
+                      if (peg$silentFails === 0) { peg$fail(peg$c42); }
+                    }
+                    if (s2 !== peg$FAILED) {
+                      s3 = peg$parseS();
+                      if (s3 !== peg$FAILED) {
+                        s4 = peg$parsenumber();
+                        if (s4 !== peg$FAILED) {
+                          s5 = peg$parseS();
+                          if (s5 !== peg$FAILED) {
+                            if (input.substr(peg$currPos, 10) === peg$c26) {
+                              s6 = peg$c26;
+                              peg$currPos += 10;
+                            } else {
+                              s6 = peg$FAILED;
+                              if (peg$silentFails === 0) { peg$fail(peg$c27); }
+                            }
+                            if (s6 !== peg$FAILED) {
+                              s7 = peg$parseS();
+                              if (s7 !== peg$FAILED) {
+                                s8 = peg$parsestring();
+                                if (s8 !== peg$FAILED) {
+                                  s9 = peg$parseS();
+                                  if (s9 !== peg$FAILED) {
+                                    if (input.substr(peg$currPos, 13) === peg$c28) {
+                                      s10 = peg$c28;
+                                      peg$currPos += 13;
+                                    } else {
+                                      s10 = peg$FAILED;
+                                      if (peg$silentFails === 0) { peg$fail(peg$c29); }
+                                    }
+                                    if (s10 !== peg$FAILED) {
+                                      s11 = peg$parseS();
+                                      if (s11 !== peg$FAILED) {
+                                        s12 = peg$parsenumber();
+                                        if (s12 !== peg$FAILED) {
+                                          s13 = peg$parserestOfLine();
+                                          if (s13 !== peg$FAILED) {
+                                            s14 = peg$parseNL();
+                                            if (s14 !== peg$FAILED) {
+                                              peg$savedPos = s0;
+                                              s1 = peg$c44(s4, s8, s12);
+                                              s0 = s1;
+                                            } else {
+                                              peg$currPos = s0;
+                                              s0 = peg$FAILED;
+                                            }
+                                          } else {
+                                            peg$currPos = s0;
+                                            s0 = peg$FAILED;
+                                          }
+                                        } else {
+                                          peg$currPos = s0;
+                                          s0 = peg$FAILED;
+                                        }
+                                      } else {
+                                        peg$currPos = s0;
+                                        s0 = peg$FAILED;
+                                      }
+                                    } else {
+                                      peg$currPos = s0;
+                                      s0 = peg$FAILED;
+                                    }
+                                  } else {
+                                    peg$currPos = s0;
+                                    s0 = peg$FAILED;
+                                  }
+                                } else {
+                                  peg$currPos = s0;
+                                  s0 = peg$FAILED;
+                                }
+                              } else {
+                                peg$currPos = s0;
+                                s0 = peg$FAILED;
+                              }
+                            } else {
+                              peg$currPos = s0;
+                              s0 = peg$FAILED;
+                            }
+                          } else {
+                            peg$currPos = s0;
+                            s0 = peg$FAILED;
+                          }
+                        } else {
+                          peg$currPos = s0;
+                          s0 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                  if (s0 === peg$FAILED) {
+                    s0 = peg$currPos;
+                    s1 = peg$parseignorableLine();
+                    if (s1 !== peg$FAILED) {
+                      peg$savedPos = s0;
+                      s1 = peg$c45();
+                    }
+                    s0 = s1;
+                  }
+                }
+              }
+            }
+
+            return s0;
+          }
+
+          function peg$parseinterface_ofdma() {
+            var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12;
+
+            s0 = peg$currPos;
+            if (input.substr(peg$currPos, 9) === peg$c5) {
+              s1 = peg$c5;
+              peg$currPos += 9;
+            } else {
+              s1 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c6); }
+            }
+            if (s1 !== peg$FAILED) {
+              s2 = peg$parseS();
+              if (s2 !== peg$FAILED) {
+                if (input.substr(peg$currPos, 5) === peg$c13) {
+                  s3 = peg$c13;
+                  peg$currPos += 5;
+                } else {
+                  s3 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c14); }
+                }
+                if (s3 !== peg$FAILED) {
+                  s4 = peg$parseS();
+                  if (s4 !== peg$FAILED) {
+                    s5 = peg$currPos;
+                    s6 = peg$currPos;
+                    s7 = peg$currPos;
+                    s8 = peg$parsenumber();
+                    if (s8 !== peg$FAILED) {
+                      if (input.charCodeAt(peg$currPos) === 58) {
+                        s9 = peg$c46;
+                        peg$currPos++;
+                      } else {
+                        s9 = peg$FAILED;
+                        if (peg$silentFails === 0) { peg$fail(peg$c47); }
+                      }
+                      if (s9 !== peg$FAILED) {
+                        s8 = [s8, s9];
+                        s7 = s8;
+                      } else {
+                        peg$currPos = s7;
+                        s7 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s7;
+                      s7 = peg$FAILED;
+                    }
+                    if (s7 === peg$FAILED) {
+                      s7 = null;
+                    }
+                    if (s7 !== peg$FAILED) {
+                      s8 = peg$parsenumber();
+                      if (s8 !== peg$FAILED) {
+                        if (input.charCodeAt(peg$currPos) === 47) {
+                          s9 = peg$c48;
+                          peg$currPos++;
+                        } else {
+                          s9 = peg$FAILED;
+                          if (peg$silentFails === 0) { peg$fail(peg$c49); }
+                        }
+                        if (s9 !== peg$FAILED) {
+                          s10 = peg$parsenumber();
+                          if (s10 !== peg$FAILED) {
+                            if (input.charCodeAt(peg$currPos) === 46) {
+                              s11 = peg$c50;
+                              peg$currPos++;
+                            } else {
+                              s11 = peg$FAILED;
+                              if (peg$silentFails === 0) { peg$fail(peg$c51); }
+                            }
+                            if (s11 !== peg$FAILED) {
+                              s12 = peg$parsenumber();
+                              if (s12 !== peg$FAILED) {
+                                s7 = [s7, s8, s9, s10, s11, s12];
+                                s6 = s7;
+                              } else {
+                                peg$currPos = s6;
+                                s6 = peg$FAILED;
+                              }
+                            } else {
+                              peg$currPos = s6;
+                              s6 = peg$FAILED;
+                            }
+                          } else {
+                            peg$currPos = s6;
+                            s6 = peg$FAILED;
+                          }
+                        } else {
+                          peg$currPos = s6;
+                          s6 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s6;
+                        s6 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s6;
+                      s6 = peg$FAILED;
+                    }
+                    if (s6 !== peg$FAILED) {
+                      s5 = input.substring(s5, peg$currPos);
+                    } else {
+                      s5 = s6;
+                    }
+                    if (s5 !== peg$FAILED) {
+                      s6 = peg$parserestOfLine();
+                      if (s6 !== peg$FAILED) {
+                        s7 = peg$parseNL();
+                        if (s7 !== peg$FAILED) {
+                          s8 = [];
+                          s9 = peg$parseinterface_ofdma_sub();
+                          if (s9 !== peg$FAILED) {
+                            while (s9 !== peg$FAILED) {
+                              s8.push(s9);
+                              s9 = peg$parseinterface_ofdma_sub();
+                            }
+                          } else {
+                            s8 = peg$FAILED;
+                          }
+                          if (s8 !== peg$FAILED) {
+                            peg$savedPos = s0;
+                            s1 = peg$c52(s5, s8);
+                            s0 = s1;
+                          } else {
+                            peg$currPos = s0;
+                            s0 = peg$FAILED;
+                          }
+                        } else {
+                          peg$currPos = s0;
+                          s0 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+
+            return s0;
+          }
+
+          function peg$parseinterface_ofdma_sub() {
+            var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10;
+
+            s0 = peg$currPos;
+            s1 = peg$parseS();
+            if (s1 !== peg$FAILED) {
+              if (input.substr(peg$currPos, 10) === peg$c53) {
+                s2 = peg$c53;
+                peg$currPos += 10;
+              } else {
+                s2 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c54); }
+              }
+              if (s2 !== peg$FAILED) {
+                s3 = peg$parseS();
+                if (s3 !== peg$FAILED) {
+                  s4 = peg$parsenumber();
+                  if (s4 !== peg$FAILED) {
+                    s5 = peg$parseS();
+                    if (s5 !== peg$FAILED) {
+                      if (input.substr(peg$currPos, 10) === peg$c55) {
+                        s6 = peg$c55;
+                        peg$currPos += 10;
+                      } else {
+                        s6 = peg$FAILED;
+                        if (peg$silentFails === 0) { peg$fail(peg$c56); }
+                      }
+                      if (s6 !== peg$FAILED) {
+                        s7 = peg$parseS();
+                        if (s7 !== peg$FAILED) {
+                          s8 = peg$parsenumber();
+                          if (s8 !== peg$FAILED) {
+                            s9 = peg$parserestOfLine();
+                            if (s9 !== peg$FAILED) {
+                              s10 = peg$parseNL();
+                              if (s10 !== peg$FAILED) {
+                                peg$savedPos = s0;
+                                s1 = peg$c57(s4, s8);
+                                s0 = s1;
+                              } else {
+                                peg$currPos = s0;
+                                s0 = peg$FAILED;
+                              }
+                            } else {
+                              peg$currPos = s0;
+                              s0 = peg$FAILED;
+                            }
+                          } else {
+                            peg$currPos = s0;
+                            s0 = peg$FAILED;
+                          }
+                        } else {
+                          peg$currPos = s0;
+                          s0 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+            if (s0 === peg$FAILED) {
+              s0 = peg$currPos;
+              s1 = peg$parseS();
+              if (s1 !== peg$FAILED) {
+                if (input.substr(peg$currPos, 11) === peg$c58) {
+                  s2 = peg$c58;
+                  peg$currPos += 11;
+                } else {
+                  s2 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c59); }
+                }
+                if (s2 !== peg$FAILED) {
+                  s3 = peg$parseS();
+                  if (s3 !== peg$FAILED) {
+                    s4 = peg$parsenumber();
+                    if (s4 !== peg$FAILED) {
+                      s5 = peg$parserestOfLine();
+                      if (s5 !== peg$FAILED) {
+                        s6 = peg$parseNL();
+                        if (s6 !== peg$FAILED) {
+                          peg$savedPos = s0;
+                          s1 = peg$c60(s4);
+                          s0 = s1;
+                        } else {
+                          peg$currPos = s0;
+                          s0 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+              if (s0 === peg$FAILED) {
+                s0 = peg$currPos;
+                s1 = peg$parseS();
+                if (s1 !== peg$FAILED) {
+                  if (input.substr(peg$currPos, 2) === peg$c61) {
+                    s2 = peg$c61;
+                    peg$currPos += 2;
+                  } else {
+                    s2 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c62); }
+                  }
+                  if (s2 === peg$FAILED) {
+                    s2 = null;
+                  }
+                  if (s2 !== peg$FAILED) {
+                    s3 = peg$parseS();
+                    if (s3 !== peg$FAILED) {
+                      if (input.substr(peg$currPos, 7) === peg$c63) {
+                        s4 = peg$c63;
+                        peg$currPos += 7;
+                      } else {
+                        s4 = peg$FAILED;
+                        if (peg$silentFails === 0) { peg$fail(peg$c64); }
+                      }
+                      if (s4 !== peg$FAILED) {
+                        s5 = peg$parseS();
+                        if (s5 !== peg$FAILED) {
+                          if (input.substr(peg$currPos, 9) === peg$c65) {
+                            s6 = peg$c65;
+                            peg$currPos += 9;
+                          } else {
+                            s6 = peg$FAILED;
+                            if (peg$silentFails === 0) { peg$fail(peg$c66); }
+                          }
+                          if (s6 !== peg$FAILED) {
+                            s7 = peg$parserestOfLine();
+                            if (s7 !== peg$FAILED) {
+                              s8 = peg$parseNL();
+                              if (s8 !== peg$FAILED) {
+                                peg$savedPos = s0;
+                                s1 = peg$c67(s2);
+                                s0 = s1;
+                              } else {
+                                peg$currPos = s0;
+                                s0 = peg$FAILED;
+                              }
+                            } else {
+                              peg$currPos = s0;
+                              s0 = peg$FAILED;
+                            }
+                          } else {
+                            peg$currPos = s0;
+                            s0 = peg$FAILED;
+                          }
+                        } else {
+                          peg$currPos = s0;
+                          s0 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+                if (s0 === peg$FAILED) {
+                  s0 = peg$currPos;
+                  s1 = peg$parseS();
+                  if (s1 !== peg$FAILED) {
+                    if (input.substr(peg$currPos, 2) === peg$c61) {
+                      s2 = peg$c61;
+                      peg$currPos += 2;
+                    } else {
+                      s2 = peg$FAILED;
+                      if (peg$silentFails === 0) { peg$fail(peg$c62); }
+                    }
+                    if (s2 === peg$FAILED) {
+                      s2 = null;
+                    }
+                    if (s2 !== peg$FAILED) {
+                      s3 = peg$parseS();
+                      if (s3 !== peg$FAILED) {
+                        if (input.substr(peg$currPos, 16) === peg$c68) {
+                          s4 = peg$c68;
+                          peg$currPos += 16;
+                        } else {
+                          s4 = peg$FAILED;
+                          if (peg$silentFails === 0) { peg$fail(peg$c69); }
+                        }
+                        if (s4 !== peg$FAILED) {
+                          s5 = peg$parseS();
+                          if (s5 !== peg$FAILED) {
+                            if (input.substr(peg$currPos, 13) === peg$c70) {
+                              s6 = peg$c70;
+                              peg$currPos += 13;
+                            } else {
+                              s6 = peg$FAILED;
+                              if (peg$silentFails === 0) { peg$fail(peg$c71); }
+                            }
+                            if (s6 !== peg$FAILED) {
+                              s7 = peg$parserestOfLine();
+                              if (s7 !== peg$FAILED) {
+                                s8 = peg$parseNL();
+                                if (s8 !== peg$FAILED) {
+                                  peg$savedPos = s0;
+                                  s1 = peg$c72(s2, s6);
+                                  s0 = s1;
+                                } else {
+                                  peg$currPos = s0;
+                                  s0 = peg$FAILED;
+                                }
+                              } else {
+                                peg$currPos = s0;
+                                s0 = peg$FAILED;
+                              }
+                            } else {
+                              peg$currPos = s0;
+                              s0 = peg$FAILED;
+                            }
+                          } else {
+                            peg$currPos = s0;
+                            s0 = peg$FAILED;
+                          }
+                        } else {
+                          peg$currPos = s0;
+                          s0 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                  if (s0 === peg$FAILED) {
+                    s0 = peg$currPos;
+                    s1 = peg$parseS();
+                    if (s1 !== peg$FAILED) {
+                      if (input.substr(peg$currPos, 14) === peg$c15) {
+                        s2 = peg$c15;
+                        peg$currPos += 14;
+                      } else {
+                        s2 = peg$FAILED;
+                        if (peg$silentFails === 0) { peg$fail(peg$c16); }
+                      }
+                      if (s2 !== peg$FAILED) {
+                        s3 = peg$parseS();
+                        if (s3 !== peg$FAILED) {
+                          s4 = peg$parsenumber();
+                          if (s4 !== peg$FAILED) {
+                            s5 = peg$parserestOfLine();
+                            if (s5 !== peg$FAILED) {
+                              s6 = peg$parseNL();
+                              if (s6 !== peg$FAILED) {
+                                peg$savedPos = s0;
+                                s1 = peg$c73(s4);
+                                s0 = s1;
+                              } else {
+                                peg$currPos = s0;
+                                s0 = peg$FAILED;
+                              }
+                            } else {
+                              peg$currPos = s0;
+                              s0 = peg$FAILED;
+                            }
+                          } else {
+                            peg$currPos = s0;
+                            s0 = peg$FAILED;
+                          }
+                        } else {
+                          peg$currPos = s0;
+                          s0 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                    if (s0 === peg$FAILED) {
+                      s0 = peg$currPos;
+                      s1 = peg$parseS();
+                      if (s1 !== peg$FAILED) {
+                        if (input.substr(peg$currPos, 11) === peg$c32) {
+                          s2 = peg$c32;
+                          peg$currPos += 11;
+                        } else {
+                          s2 = peg$FAILED;
+                          if (peg$silentFails === 0) { peg$fail(peg$c33); }
+                        }
+                        if (s2 !== peg$FAILED) {
+                          s3 = peg$parseS();
+                          if (s3 !== peg$FAILED) {
+                            s4 = peg$parsenumber();
+                            if (s4 !== peg$FAILED) {
+                              s5 = peg$parserestOfLine();
+                              if (s5 !== peg$FAILED) {
+                                s6 = peg$parseNL();
+                                if (s6 !== peg$FAILED) {
+                                  peg$savedPos = s0;
+                                  s1 = peg$c74(s4);
+                                  s0 = s1;
+                                } else {
+                                  peg$currPos = s0;
+                                  s0 = peg$FAILED;
+                                }
+                              } else {
+                                peg$currPos = s0;
+                                s0 = peg$FAILED;
+                              }
+                            } else {
+                              peg$currPos = s0;
+                              s0 = peg$FAILED;
+                            }
+                          } else {
+                            peg$currPos = s0;
+                            s0 = peg$FAILED;
+                          }
+                        } else {
+                          peg$currPos = s0;
+                          s0 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$FAILED;
+                      }
+                      if (s0 === peg$FAILED) {
+                        s0 = peg$currPos;
+                        s1 = peg$parseS();
+                        if (s1 !== peg$FAILED) {
+                          if (input.substr(peg$currPos, 13) === peg$c75) {
+                            s2 = peg$c75;
+                            peg$currPos += 13;
+                          } else {
+                            s2 = peg$FAILED;
+                            if (peg$silentFails === 0) { peg$fail(peg$c76); }
+                          }
+                          if (s2 !== peg$FAILED) {
+                            s3 = peg$parseS();
+                            if (s3 !== peg$FAILED) {
+                              s4 = peg$parsenumber();
+                              if (s4 !== peg$FAILED) {
+                                s5 = peg$parserestOfLine();
+                                if (s5 !== peg$FAILED) {
+                                  s6 = peg$parseNL();
+                                  if (s6 !== peg$FAILED) {
+                                    peg$savedPos = s0;
+                                    s1 = peg$c77(s4);
+                                    s0 = s1;
+                                  } else {
+                                    peg$currPos = s0;
+                                    s0 = peg$FAILED;
+                                  }
+                                } else {
+                                  peg$currPos = s0;
+                                  s0 = peg$FAILED;
+                                }
+                              } else {
+                                peg$currPos = s0;
+                                s0 = peg$FAILED;
+                              }
+                            } else {
+                              peg$currPos = s0;
+                              s0 = peg$FAILED;
+                            }
+                          } else {
+                            peg$currPos = s0;
+                            s0 = peg$FAILED;
+                          }
+                        } else {
+                          peg$currPos = s0;
+                          s0 = peg$FAILED;
+                        }
+                        if (s0 === peg$FAILED) {
+                          s0 = peg$currPos;
+                          s1 = peg$parseS();
+                          if (s1 !== peg$FAILED) {
+                            if (input.substr(peg$currPos, 14) === peg$c78) {
+                              s2 = peg$c78;
+                              peg$currPos += 14;
+                            } else {
+                              s2 = peg$FAILED;
+                              if (peg$silentFails === 0) { peg$fail(peg$c79); }
+                            }
+                            if (s2 !== peg$FAILED) {
+                              s3 = peg$parseS();
+                              if (s3 !== peg$FAILED) {
+                                s4 = peg$parsenumber();
+                                if (s4 !== peg$FAILED) {
+                                  s5 = peg$parserestOfLine();
+                                  if (s5 !== peg$FAILED) {
+                                    s6 = peg$parseNL();
+                                    if (s6 !== peg$FAILED) {
+                                      peg$savedPos = s0;
+                                      s1 = peg$c80(s4);
+                                      s0 = s1;
+                                    } else {
+                                      peg$currPos = s0;
+                                      s0 = peg$FAILED;
+                                    }
+                                  } else {
+                                    peg$currPos = s0;
+                                    s0 = peg$FAILED;
+                                  }
+                                } else {
+                                  peg$currPos = s0;
+                                  s0 = peg$FAILED;
+                                }
+                              } else {
+                                peg$currPos = s0;
+                                s0 = peg$FAILED;
+                              }
+                            } else {
+                              peg$currPos = s0;
+                              s0 = peg$FAILED;
+                            }
+                          } else {
+                            peg$currPos = s0;
+                            s0 = peg$FAILED;
+                          }
+                          if (s0 === peg$FAILED) {
+                            s0 = peg$currPos;
+                            s1 = peg$parseS();
+                            if (s1 !== peg$FAILED) {
+                              if (input.substr(peg$currPos, 10) === peg$c81) {
+                                s2 = peg$c81;
+                                peg$currPos += 10;
+                              } else {
+                                s2 = peg$FAILED;
+                                if (peg$silentFails === 0) { peg$fail(peg$c82); }
+                              }
+                              if (s2 !== peg$FAILED) {
+                                s3 = peg$parseS();
+                                if (s3 !== peg$FAILED) {
+                                  s4 = peg$parsenumber();
+                                  if (s4 !== peg$FAILED) {
+                                    s5 = peg$parserestOfLine();
+                                    if (s5 !== peg$FAILED) {
+                                      s6 = peg$parseNL();
+                                      if (s6 !== peg$FAILED) {
+                                        peg$savedPos = s0;
+                                        s1 = peg$c83(s4);
+                                        s0 = s1;
+                                      } else {
+                                        peg$currPos = s0;
+                                        s0 = peg$FAILED;
+                                      }
+                                    } else {
+                                      peg$currPos = s0;
+                                      s0 = peg$FAILED;
+                                    }
+                                  } else {
+                                    peg$currPos = s0;
+                                    s0 = peg$FAILED;
+                                  }
+                                } else {
+                                  peg$currPos = s0;
+                                  s0 = peg$FAILED;
+                                }
+                              } else {
+                                peg$currPos = s0;
+                                s0 = peg$FAILED;
+                              }
+                            } else {
+                              peg$currPos = s0;
+                              s0 = peg$FAILED;
+                            }
+                            if (s0 === peg$FAILED) {
+                              s0 = peg$currPos;
+                              s1 = peg$parseS();
+                              if (s1 !== peg$FAILED) {
+                                if (input.substr(peg$currPos, 2) === peg$c61) {
+                                  s2 = peg$c61;
+                                  peg$currPos += 2;
+                                } else {
+                                  s2 = peg$FAILED;
+                                  if (peg$silentFails === 0) { peg$fail(peg$c62); }
+                                }
+                                if (s2 === peg$FAILED) {
+                                  s2 = null;
+                                }
+                                if (s2 !== peg$FAILED) {
+                                  s3 = peg$parseS();
+                                  if (s3 !== peg$FAILED) {
+                                    if (input.substr(peg$currPos, 8) === peg$c84) {
+                                      s4 = peg$c84;
+                                      peg$currPos += 8;
+                                    } else {
+                                      s4 = peg$FAILED;
+                                      if (peg$silentFails === 0) { peg$fail(peg$c85); }
+                                    }
+                                    if (s4 !== peg$FAILED) {
+                                      peg$savedPos = s0;
+                                      s1 = peg$c86(s2);
+                                      s0 = s1;
+                                    } else {
+                                      peg$currPos = s0;
+                                      s0 = peg$FAILED;
+                                    }
+                                  } else {
+                                    peg$currPos = s0;
+                                    s0 = peg$FAILED;
+                                  }
+                                } else {
+                                  peg$currPos = s0;
+                                  s0 = peg$FAILED;
+                                }
+                              } else {
+                                peg$currPos = s0;
+                                s0 = peg$FAILED;
+                              }
+                              if (s0 === peg$FAILED) {
+                                s0 = peg$currPos;
+                                s1 = peg$parseignorableLine();
+                                if (s1 !== peg$FAILED) {
+                                  peg$savedPos = s0;
+                                  s1 = peg$c45();
+                                }
+                                s0 = s1;
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+
+            return s0;
+          }
+
+          function peg$parseignorableLine() {
+            var s0, s1, s2;
+
+            s0 = peg$currPos;
+            s1 = peg$currPos;
+            peg$silentFails++;
+            if (input.substr(peg$currPos, 5) === peg$c13) {
+              s2 = peg$c13;
+              peg$currPos += 5;
+            } else {
+              s2 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c14); }
+            }
+            if (s2 === peg$FAILED) {
+              if (input.substr(peg$currPos, 9) === peg$c5) {
+                s2 = peg$c5;
+                peg$currPos += 9;
+              } else {
+                s2 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c6); }
+              }
+              if (s2 === peg$FAILED) {
+                if (input.substr(peg$currPos, 10) === peg$c26) {
+                  s2 = peg$c26;
+                  peg$currPos += 10;
+                } else {
+                  s2 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c27); }
+                }
+              }
+            }
+            peg$silentFails--;
+            if (s2 === peg$FAILED) {
+              s1 = void 0;
+            } else {
+              peg$currPos = s1;
+              s1 = peg$FAILED;
+            }
+            if (s1 !== peg$FAILED) {
+              s2 = peg$parseanyLine();
+              if (s2 !== peg$FAILED) {
+                s1 = [s1, s2];
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+
+            return s0;
+          }
+
+          function peg$parseanyLine() {
+            var s0, s1, s2, s3, s4;
+
+            s0 = peg$currPos;
+            s1 = [];
+            s2 = peg$currPos;
+            s3 = peg$currPos;
+            peg$silentFails++;
+            s4 = peg$parseNL();
+            peg$silentFails--;
+            if (s4 === peg$FAILED) {
+              s3 = void 0;
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+            if (s3 !== peg$FAILED) {
+              if (input.length > peg$currPos) {
+                s4 = input.charAt(peg$currPos);
+                peg$currPos++;
+              } else {
+                s4 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c0); }
+              }
+              if (s4 !== peg$FAILED) {
+                s3 = [s3, s4];
+                s2 = s3;
+              } else {
+                peg$currPos = s2;
+                s2 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s2;
+              s2 = peg$FAILED;
+            }
+            if (s2 !== peg$FAILED) {
+              while (s2 !== peg$FAILED) {
+                s1.push(s2);
+                s2 = peg$currPos;
+                s3 = peg$currPos;
+                peg$silentFails++;
+                s4 = peg$parseNL();
+                peg$silentFails--;
+                if (s4 === peg$FAILED) {
+                  s3 = void 0;
+                } else {
+                  peg$currPos = s3;
+                  s3 = peg$FAILED;
+                }
+                if (s3 !== peg$FAILED) {
+                  if (input.length > peg$currPos) {
+                    s4 = input.charAt(peg$currPos);
+                    peg$currPos++;
+                  } else {
+                    s4 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c0); }
+                  }
+                  if (s4 !== peg$FAILED) {
+                    s3 = [s3, s4];
+                    s2 = s3;
+                  } else {
+                    peg$currPos = s2;
+                    s2 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s2;
+                  s2 = peg$FAILED;
+                }
+              }
+            } else {
+              s1 = peg$FAILED;
+            }
+            if (s1 !== peg$FAILED) {
+              s2 = [];
+              s3 = peg$parseNL();
+              if (s3 !== peg$FAILED) {
+                while (s3 !== peg$FAILED) {
+                  s2.push(s3);
+                  s3 = peg$parseNL();
+                }
+              } else {
+                s2 = peg$FAILED;
+              }
+              if (s2 !== peg$FAILED) {
+                s1 = [s1, s2];
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+
+            return s0;
+          }
+
+          function peg$parserestOfLine() {
+            var s0, s1, s2, s3;
+
+            s0 = [];
+            s1 = peg$currPos;
+            s2 = peg$currPos;
+            peg$silentFails++;
+            s3 = peg$parseNL();
+            peg$silentFails--;
+            if (s3 === peg$FAILED) {
+              s2 = void 0;
+            } else {
+              peg$currPos = s2;
+              s2 = peg$FAILED;
+            }
+            if (s2 !== peg$FAILED) {
+              if (input.length > peg$currPos) {
+                s3 = input.charAt(peg$currPos);
+                peg$currPos++;
+              } else {
+                s3 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c0); }
+              }
+              if (s3 !== peg$FAILED) {
+                s2 = [s2, s3];
+                s1 = s2;
+              } else {
+                peg$currPos = s1;
+                s1 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s1;
+              s1 = peg$FAILED;
+            }
+            while (s1 !== peg$FAILED) {
+              s0.push(s1);
+              s1 = peg$currPos;
+              s2 = peg$currPos;
+              peg$silentFails++;
+              s3 = peg$parseNL();
+              peg$silentFails--;
+              if (s3 === peg$FAILED) {
+                s2 = void 0;
+              } else {
+                peg$currPos = s2;
+                s2 = peg$FAILED;
+              }
+              if (s2 !== peg$FAILED) {
+                if (input.length > peg$currPos) {
+                  s3 = input.charAt(peg$currPos);
+                  peg$currPos++;
+                } else {
+                  s3 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c0); }
+                }
+                if (s3 !== peg$FAILED) {
+                  s2 = [s2, s3];
+                  s1 = s2;
+                } else {
+                  peg$currPos = s1;
+                  s1 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s1;
+                s1 = peg$FAILED;
+              }
+            }
+
+            return s0;
+          }
+
+          function peg$parseS() {
+            var s0, s1;
+
+            s0 = [];
+            if (input.charCodeAt(peg$currPos) === 32) {
+              s1 = peg$c87;
+              peg$currPos++;
+            } else {
+              s1 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c88); }
+            }
+            if (s1 === peg$FAILED) {
+              if (input.charCodeAt(peg$currPos) === 9) {
+                s1 = peg$c89;
+                peg$currPos++;
+              } else {
+                s1 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c90); }
+              }
+            }
+            while (s1 !== peg$FAILED) {
+              s0.push(s1);
+              if (input.charCodeAt(peg$currPos) === 32) {
+                s1 = peg$c87;
+                peg$currPos++;
+              } else {
+                s1 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c88); }
+              }
+              if (s1 === peg$FAILED) {
+                if (input.charCodeAt(peg$currPos) === 9) {
+                  s1 = peg$c89;
+                  peg$currPos++;
+                } else {
+                  s1 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c90); }
+                }
+              }
+            }
+
+            return s0;
+          }
+
+          function peg$parseNL() {
+            var s0, s1;
+
+            s0 = [];
+            if (input.substr(peg$currPos, 2) === peg$c91) {
+              s1 = peg$c91;
+              peg$currPos += 2;
+            } else {
+              s1 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c92); }
+            }
+            if (s1 === peg$FAILED) {
+              if (input.charCodeAt(peg$currPos) === 10) {
+                s1 = peg$c93;
+                peg$currPos++;
+              } else {
+                s1 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c94); }
+              }
+              if (s1 === peg$FAILED) {
+                if (input.charCodeAt(peg$currPos) === 13) {
+                  s1 = peg$c95;
+                  peg$currPos++;
+                } else {
+                  s1 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c96); }
+                }
+              }
+            }
+            if (s1 !== peg$FAILED) {
+              while (s1 !== peg$FAILED) {
+                s0.push(s1);
+                if (input.substr(peg$currPos, 2) === peg$c91) {
+                  s1 = peg$c91;
+                  peg$currPos += 2;
+                } else {
+                  s1 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c92); }
+                }
+                if (s1 === peg$FAILED) {
+                  if (input.charCodeAt(peg$currPos) === 10) {
+                    s1 = peg$c93;
+                    peg$currPos++;
+                  } else {
+                    s1 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c94); }
+                  }
+                  if (s1 === peg$FAILED) {
+                    if (input.charCodeAt(peg$currPos) === 13) {
+                      s1 = peg$c95;
+                      peg$currPos++;
+                    } else {
+                      s1 = peg$FAILED;
+                      if (peg$silentFails === 0) { peg$fail(peg$c96); }
+                    }
+                  }
+                }
+              }
+            } else {
+              s0 = peg$FAILED;
+            }
+
+            return s0;
+          }
+
+          function peg$parsefloat() {
+            var s0, s1, s2, s3, s4, s5, s6;
+
+            s0 = peg$currPos;
+            s1 = peg$currPos;
+            s2 = peg$currPos;
+            s3 = [];
+            if (peg$c97.test(input.charAt(peg$currPos))) {
+              s4 = input.charAt(peg$currPos);
+              peg$currPos++;
+            } else {
+              s4 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c98); }
+            }
+            if (s4 !== peg$FAILED) {
+              while (s4 !== peg$FAILED) {
+                s3.push(s4);
+                if (peg$c97.test(input.charAt(peg$currPos))) {
+                  s4 = input.charAt(peg$currPos);
+                  peg$currPos++;
+                } else {
+                  s4 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c98); }
+                }
+              }
+            } else {
+              s3 = peg$FAILED;
+            }
+            if (s3 !== peg$FAILED) {
+              if (input.charCodeAt(peg$currPos) === 46) {
+                s4 = peg$c50;
+                peg$currPos++;
+              } else {
+                s4 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c51); }
+              }
+              if (s4 !== peg$FAILED) {
+                s5 = [];
+                if (peg$c97.test(input.charAt(peg$currPos))) {
+                  s6 = input.charAt(peg$currPos);
+                  peg$currPos++;
+                } else {
+                  s6 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c98); }
+                }
+                if (s6 !== peg$FAILED) {
+                  while (s6 !== peg$FAILED) {
+                    s5.push(s6);
+                    if (peg$c97.test(input.charAt(peg$currPos))) {
+                      s6 = input.charAt(peg$currPos);
+                      peg$currPos++;
+                    } else {
+                      s6 = peg$FAILED;
+                      if (peg$silentFails === 0) { peg$fail(peg$c98); }
+                    }
+                  }
+                } else {
+                  s5 = peg$FAILED;
+                }
+                if (s5 !== peg$FAILED) {
+                  s3 = [s3, s4, s5];
+                  s2 = s3;
+                } else {
+                  peg$currPos = s2;
+                  s2 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s2;
+                s2 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s2;
+              s2 = peg$FAILED;
+            }
+            if (s2 !== peg$FAILED) {
+              s1 = input.substring(s1, peg$currPos);
+            } else {
+              s1 = s2;
+            }
+            if (s1 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c99(s1);
+            }
+            s0 = s1;
+
+            return s0;
+          }
+
+          function peg$parsenumber() {
+            var s0, s1, s2, s3, s4, s5;
+
+            s0 = peg$currPos;
+            s1 = peg$currPos;
+            s2 = peg$currPos;
+            if (input.charCodeAt(peg$currPos) === 45) {
+              s3 = peg$c10;
+              peg$currPos++;
+            } else {
+              s3 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c11); }
+            }
+            if (s3 === peg$FAILED) {
+              s3 = null;
+            }
+            if (s3 !== peg$FAILED) {
+              s4 = [];
+              if (peg$c97.test(input.charAt(peg$currPos))) {
+                s5 = input.charAt(peg$currPos);
+                peg$currPos++;
+              } else {
+                s5 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c98); }
+              }
+              if (s5 !== peg$FAILED) {
+                while (s5 !== peg$FAILED) {
+                  s4.push(s5);
+                  if (peg$c97.test(input.charAt(peg$currPos))) {
+                    s5 = input.charAt(peg$currPos);
+                    peg$currPos++;
+                  } else {
+                    s5 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c98); }
+                  }
+                }
+              } else {
+                s4 = peg$FAILED;
+              }
+              if (s4 !== peg$FAILED) {
+                s3 = [s3, s4];
+                s2 = s3;
+              } else {
+                peg$currPos = s2;
+                s2 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s2;
+              s2 = peg$FAILED;
+            }
+            if (s2 !== peg$FAILED) {
+              s1 = input.substring(s1, peg$currPos);
+            } else {
+              s1 = s2;
+            }
+            if (s1 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c100(s1);
+            }
+            s0 = s1;
+
+            return s0;
+          }
+
+          function peg$parsestring() {
+            var s0, s1, s2;
+
+            s0 = peg$currPos;
+            s1 = [];
+            if (peg$c101.test(input.charAt(peg$currPos))) {
+              s2 = input.charAt(peg$currPos);
+              peg$currPos++;
+            } else {
+              s2 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c102); }
+            }
+            if (s2 !== peg$FAILED) {
+              while (s2 !== peg$FAILED) {
+                s1.push(s2);
+                if (peg$c101.test(input.charAt(peg$currPos))) {
+                  s2 = input.charAt(peg$currPos);
+                  peg$currPos++;
+                } else {
+                  s2 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c102); }
+                }
+              }
+            } else {
+              s1 = peg$FAILED;
+            }
+            if (s1 !== peg$FAILED) {
+              s0 = input.substring(s0, peg$currPos);
+            } else {
+              s0 = s1;
+            }
+
+            return s0;
+          }
+
+
+          const minislotConfigs = {};
+          const iucProfiles = {};
+          const ofdmaInterfaces = {};
+          const exclusionBands = {};
+          const serviceGroups = {};
+          const modulationProfiles = {};
+
+
+          peg$result = peg$startRuleFunction();
+
+          if (peg$result !== peg$FAILED && peg$currPos === input.length) {
+            return peg$result;
+          } else {
+            if (peg$result !== peg$FAILED && peg$currPos < input.length) {
+              peg$fail(peg$endExpectation());
+            }
+
+            throw peg$buildStructuredError(
+              peg$maxFailExpected,
+              peg$maxFailPos < input.length ? input.charAt(peg$maxFailPos) : null,
+              peg$maxFailPos < input.length
+                ? peg$computeLocation(peg$maxFailPos, peg$maxFailPos + 1)
+                : peg$computeLocation(peg$maxFailPos, peg$maxFailPos)
+            );
+          }
+        }
+
+        return {
+          SyntaxError: peg$SyntaxError,
+          parse: peg$parse
+        };
+      })();
+
+
+
+
+  </script>
+</head>
+
+<body>
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-6">
+        <div class="card">
+          <div class="card-header">
+            OFDMA Channel Parameters
+          </div>
+          <div class="card-body" style="height:27em;">
+            <form>
+              <div class="row g-3 align-items-left">
+                <div class="col-3">
+                  <label for="subcarrierSpacing" class="form-label">Subcarrier Spacing</label>
+                </div>
+                <div class="col-auto">
+                  <select class="form-control" id="subcarrierSpacing">
+                    <option value="50000">50 KHz</option>
+                    <option value="25000">25 KHz</option>
+                  </select>
+                </div>
+                <div class="col-auto">&nbsp;</div>
+              </div>
+              <div class="row g-3 align-items-left">
+                <div class="col-3">
+                  <label for="boundaryType" class="form-label">Frequency Boundary Type</label>
+                </div>
+                <div class="col-auto">
+                  <select class="form-control" id="boundaryType">
+                    <option value="manual">Outside Data Subcarrier Edges (Casa)</option>
+                    <option selected="true" value="auto">Outside Data Subcarrier Centers (Everyone Else)</option>
+                  </select>
+                </div>
+                <div class="col-auto">&nbsp;</div>
+              </div>
+              <div class="row g-3 align-items-left">
+                <div class="col-3">
+                  <label for="lowerFreq" class="form-label">Lower Frequency</label>
+                </div>
+                <div class="col-3">
+                  <input type="text" class="form-control" id="lowerFreq" aria-describedby="lowerFreqHelp"
+                    value="" /><span id="lowerActual" style="color: red;"></span>
+                </div>
+                <div class="col-6">
+                  <div id="lowerFreqHelp" class="form-text">Represents the center frequency of the first potential Data
+                    Subcarrier </div><div style="color: red;" id="lowerFreqProblem"></div>
+                </div>
+              </div>
+              <div class="row g-3 align-items-left">
+                <div class="col-3">
+                  <label for="upperFreq" class="form-label">Upper Frequency</label>
+                </div>
+                <div class="col-3">
+                  <input type="text" class="form-control" id="upperFreq" aria-describedby="upperFreqHelp"
+                    value="25000000" /><span id="upperActual" style="color: red;">
+                  </span>
+                </div>
+                <div class="col-6">
+                  <div id="upperFreqHelp" class="form-text">Represents the center frequency of the last potential
+                  Data Subcarrier </div><div style="color: red;" id="upperFreqProblem"></div>
+                </div>
+              </div>
+              <div class="row g-3 align-items-left">
+                <div class="col-3">
+                  <label for="minislots" class="form-label">Minislots</label>
+                </div>
+                <div class="col-3">
+                  <input type="text" class="form-control" id="minislots" aria-describedby="minislotsHelp" value=""
+                    disabled="true">
+                </div>
+                <div class="col-auto">
+
+                </div>
+              </div>
+              <div class="row g-3 align-items-left">
+                <div class="col-3">
+                  <label for="unusedCarriers" class="form-label">Unused Subcarriers</label>
+                </div>
+                <div class="col-3">
+                  <input type="text" class="form-control" id="unusedCarriers" aria-describedby="unusedCarriersHelp"
+                    value="" disabled="true">
+                </div>
+                <div class="col-auto">
+
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+      <div class="col-6">
+        <div class="card">
+          <div class="card-header">
+            From Casa Configuration
+          </div>
+          <div class="card-body" style="height:95%;">
+            <label for="input">Load From CMTS Configuration &nbsp; <button id="btn8643" data-toggle="tooltip"
+                data-placement="top" title="Copy To Clipboard">Copy 8.6.4.3 Commands</button>&nbsp;<button id="btnOlder"
+                data-toggle="tooltip" data-placement="top" title="Copy To Clipboard">Copy Older Versions
+                Commands</button></label><textarea id="input" style="width:100%;height:20em;"
+              placeholder="for 8.6.4.3+&#10;show running-config ofdma active hierarchy&#10;show interface docsis-mac topology | in tdma|ofdma|^interface&#10;show modulation-profile | in ^modulation|long&#10;&#10;For Older versions&#10;show ofdma exclusion-band&#10;show ofdma minislot-cfg&#10;show ofdma iuc-profile&#10;show interface ofdma&#10;show interface docsis-mac topology | in tdma|ofdma|^interface&#10;show modulation-profile | in ^modulation|long"></textarea>
+            <textarea id="code8643" style="display:none">page off
+show running-config ofdma active hierarchy
+show interface docsis-mac topology | in tdma|ofdma|^interface
+show modulation-profile | in ^modulation|long
+</textarea>
+            <textarea id="codeOlder" style="display:none">page off
+show ofdma exclusion-band
+show ofdma minislot-cfg
+show ofdma iuc-profile
+show interface ofdma
+show interface docsis-mac topology | in tdma|ofdma|^interface
+show modulation-profile | in ^modulation|long
+</textarea>
+            <button id="parseInput" disabled>Parse</button>
+            <label for="activeInterfaces">Active OFDMA Interfaces</label><select id="activeInterfaces" disabled>
+              <option>None</option>
+            </select> <button id="loadConfig" disabled>Load</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-6">
+        <div class="card">
+          <div class="card-header">
+            Subcarriers
+          </div>
+          <div class="card-body" style="height:27em;">
+            <div id="subcarrierTable"></div>
+          </div>
+        </div>
+      </div>
+      <div class="col-6">
+        <div class="card">
+          <div class="card-header">
+            Minislot Visualization
+          </div>
+          <div class="card-body" style="height:27em;">
+            <div id="minislotVisualization" style="height:27em;"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-6">
+        <div class="card">
+          <div class="card-header">
+            Minislot Configuration
+          </div>
+          <div class="card-body" style="height:27em;">
+            <div id="minislotTable"></div>
+          </div>
+        </div>
+      </div>
+      <div class="col-6">
+        <div class="card">
+          <div class="card-header">
+            Minislot RxMER Required Visualization
+          </div>
+          <div class="card-body" style="height:27em;">
+            <div style="height: 100%;" id="minislotRxMerVisualization"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-6">
+        <div class="card">
+          <div class="card-header">
+            TaFDM Parameters
+          </div>
+          <div class="card-body" style="height:27em;">
+            <label>OFDMA RxPower</label>
+            <input type="text" id="ofdmaRxPower" value="-6" />
+            <div id="adjacentUpstreams"></div>
+          </div>
+        </div>
+      </div>
+      <div class="col-6">
+        <div class="card">
+          <div class="card-header">
+            Casa Spectrum/Guardband Visualization
+          </div>
+          <div class="card-body" style="height:27em;">
+            <div id="tafdmGuardband"></div>
+            <div style="height: 100%;" id="tafdmVisualization"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-12">
+        <div class="card">
+          <div class="card-header">
+            Power Spectral Density Calculation
+          </div>
+          <div class="card-body" style="height:27em;">
+
+            <div id="psdVisualization" style="height:100%"></div>
+          </div>
+        </div>
+      </div>
+      
+    </div>
+    <div class="row">
+      <div class="col-5">
+        <div class="card">
+          <div class="card-header">
+            Casa Config Generation Parameters
+          </div>
+          <div class="card-body" style="height:27em;">
+            <label><b>interface ofdma</b></label>
+            <input type="text" id="ofdmaInterfaceName" value="0/0.0" /><br />
+            <label><b>Pre-equalization&nbsp;</b></label><input type="checkbox" id="ofdmaPreEqualization"
+              checked="true" />
+            <label><b>Auto-Decision&nbsp;</b></label><input type="checkbox" id="ofdmaPreEqualizationAutoDecision"
+              checked="true" /><br />
+            <label><b>IUC Profile Number</b></label><input type="text" id="ofdmaIucProfileNumber" value="1" /><br />
+            <label><b>Exclusion Band Index</b></label><input type="text" id="ofdmaexclusionBandNumber"
+              value="1" /><br />
+            <label><b>IUC 5 Minislot-cfg Index</b></label><input type="text" id="iucMinislotIndex5" value="5" /><br />
+            <label><b>IUC 6 Minislot-cfg Index</b></label><input type="text" id="iucMinislotIndex6" value="6" /><br />
+            <label><b>IUC 9 Minislot-cfg Index</b></label><input type="text" id="iucMinislotIndex9" value="9" /><br />
+            <label><b>IUC 10 Minislot-cfg Index</b></label><input type="text" id="iucMinislotIndex10"
+              value="10" /><br />
+            <label><b>IUC 11 Minislot-cfg Index</b></label><input type="text" id="iucMinislotIndex11"
+              value="11" /><br />
+            <label><b>IUC 12 Minislot-cfg Index</b></label><input type="text" id="iucMinislotIndex12"
+              value="12" /><br />
+            <label><b>IUC 13 Minislot-cfg Index</b></label><input type="text" id="iucMinislotIndex13"
+              value="13" /><br />
+          </div>
+        </div>
+      </div>
+      <div class="col-7">
+        <div class="card">
+          <div class="card-header">
+            Casa Generated Config
+          </div>
+          <div class="card-body" style="height:27em;">
+            <textarea style="height: 100%; width:100%;" disabled="true" id="generatedConfig"></textarea>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+
+</html>


### PR DESCRIPTION
OFDMA calculator to show where subcarriers and minislots are and to calculate bandwidth based on minislot config e.g. Modulation and Pilot Pattern

Some of the features are Casa specific, like config parsing/loading and config generation and TaFDM calculations, but the rest should carryover to any D3.1 CMTS.

Note: Casa defined their OFDMA channels different than everyone else, it was per the spec, but it was not as user friendly. As such the lower-frequency and upper-frequency have different meanings depending on whether it is a Casa or not.

For Casa, the lower frequency corresponds to the start frequency of the first potential data subcarrier. The upper frequency corresponds to the end frequency of the last potential data subcarrier.

For everyone else, the lower and upper frequencies correspond to the center frequency of the first and last potential subcarrier respectfully.

Regardless of the method channel creation does not work how most people expect. The expectation is you define a lower frequency and an upper frequency that are some multiple of 400 KHz apart and a channel of corresponding size is created. 

There is a rule in the Docsis Spec that says that every center frequency of a subcarrier (50 KHz or 25 KHz wide) must be divisible by the subcarrier spacing this is where the two initialization methods differ.

Casa uses lower and upper frequencies as the bounds and moves the first and last subcarriers inward until above rule is met.
Everyone else uses a bounds on the center frequency and potentially expands beyond those bounds to create the channel.